### PR TITLE
server side encryption & private teams (backend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ ENCRYPTION_KEY=base64_32_bytes
 # secondary key used for rotation/decryption
 ENCRYPTION_KEY_SECONDARY=base64_32_bytes
 # stable lookup key for hashing (keep constant across rotations)
-ENCRYPTION_LOOKUP_KEY=base64_32_bytes
+ENCRYPTION_KEY_LOOKUP=base64_32_bytes
 
 # csp headers
 UNSAFE_DEACTIVATE_CSP=false

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ SESSION_SECRET=session_value
 ENCRYPTION_KEY=base64_32_bytes
 # secondary key used for rotation/decryption
 ENCRYPTION_KEY_SECONDARY=base64_32_bytes
+# stable lookup key for hashing (keep constant across rotations)
+ENCRYPTION_LOOKUP_KEY=base64_32_bytes
 
 # csp headers
 UNSAFE_DEACTIVATE_CSP=false

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ REDIS_PORT=6379
 # session secret
 SESSION_SECRET=session_value
 
+# encryption key (openssl rand -base64 32)
+ENCRYPTION_KEY=base64_32_bytes
+# secondary key used for rotation/decryption
+ENCRYPTION_KEY_SECONDARY=base64_32_bytes
+
 # csp headers
 UNSAFE_DEACTIVATE_CSP=false
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          # Upload entire repository
+          # Upload built documentation
           path: 'docs/book'
         
       - name: Deploy to GitHub Pages

--- a/backend/src/controllers/team.controller.ts
+++ b/backend/src/controllers/team.controller.ts
@@ -41,9 +41,53 @@ export const setJoinedTeams = async (req: Request, res: Response, next: NextFunc
   }
 };
 
+export const addPrivateTeam = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    await teamService.addPrivateTeam(req.body, req.session);
+    res.sendStatus(200);
+  }
+  catch (error) {
+    next(error);
+  }
+};
+
+export const joinPrivateTeam = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    await teamService.joinPrivateTeam(req.body, req.session);
+    res.sendStatus(200);
+  }
+  catch (error) {
+    next(error);
+  }
+};
+
+export const deletePrivateTeam = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    await teamService.deletePrivateTeam(req.body, req.session);
+    res.sendStatus(200);
+  }
+  catch (error) {
+    next(error);
+  }
+};
+
+export const leavePrivateTeam = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    await teamService.leavePrivateTeam(req.body, req.session);
+    res.sendStatus(200);
+  }
+  catch (error) {
+    next(error);
+  }
+};
+
 export default {
   getTeams,
   setTeams,
   getJoinedTeams,
-  setJoinedTeams
+  setJoinedTeams,
+  addPrivateTeam,
+  joinPrivateTeam,
+  deletePrivateTeam,
+  leavePrivateTeam
 };

--- a/backend/src/controllers/upload.controller.ts
+++ b/backend/src/controllers/upload.controller.ts
@@ -19,7 +19,7 @@ export const getUploadFile = async (req: Request, res: Response, next: NextFunct
     const { stream, headers } = await uploadService.getUploadFile({
       fileIdParam: parseInt(req.params.fileId, 10),
       action: req.query.action as getUploadFileType["query"]["action"],
-      classId: req.session.classId!
+      session: req.session
     });
 
     res.setHeader("Content-Type", headers["Content-Type"]);

--- a/backend/src/middleware/error.middleware.ts
+++ b/backend/src/middleware/error.middleware.ts
@@ -1,9 +1,10 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import { RequestError } from "../@types/requestError";
 import logger from "../config/logger";
 import { performUploadCleanup } from "../utils/upload.cleanup";
 
-export async function ErrorHandler(err: RequestError, req: Request, res: Response): Promise<void> {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function ErrorHandler(err: RequestError, req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     // Clean up temp files and roll back reserved storage quota if needed
     await performUploadCleanup(req, res, "error");
@@ -22,7 +23,7 @@ export async function ErrorHandler(err: RequestError, req: Request, res: Respons
     }
   }
   catch (err) {
-    logger.warn("An error occured in the error handler middleware", {
+    logger.warn("An error occurred in the error handler middleware", {
       requestId: res.locals.requestId,
       method: req.method,
       path: req.originalUrl || req.url,

--- a/backend/src/prisma/migrations/20260201193343_add_class_code_hash_for_server_encryption/migration.sql
+++ b/backend/src/prisma/migrations/20260201193343_add_class_code_hash_for_server_encryption/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "class" ADD COLUMN "classCodeHash" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "class_classCodeHash_key" ON "class"("classCodeHash");

--- a/backend/src/prisma/migrations/20260202214954_add_private_teams/migration.sql
+++ b/backend/src/prisma/migrations/20260202214954_add_private_teams/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[inviteCode]` on the table `team` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[inviteCodeHash]` on the table `team` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "team" ADD COLUMN     "inviteCode" TEXT,
+ADD COLUMN     "inviteCodeHash" TEXT,
+ADD COLUMN     "isPrivate" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "team_inviteCode_key" ON "team"("inviteCode");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "team_inviteCodeHash_key" ON "team"("inviteCodeHash");

--- a/backend/src/prisma/migrations/20260202214954_add_private_teams/migration.sql
+++ b/backend/src/prisma/migrations/20260202214954_add_private_teams/migration.sql
@@ -1,17 +1,34 @@
 /*
-  Warnings:
-
-  - A unique constraint covering the columns `[inviteCode]` on the table `team` will be added. If there are existing duplicate values, this will fail.
-  - A unique constraint covering the columns `[inviteCodeHash]` on the table `team` will be added. If there are existing duplicate values, this will fail.
-
+  This migration (v2.3.0) adds private team feature, rm an unnecessary unique index and creates new indexes for sorting when getting data.
 */
--- AlterTable
-ALTER TABLE "team" ADD COLUMN     "inviteCode" TEXT,
-ADD COLUMN     "inviteCodeHash" TEXT,
-ADD COLUMN     "isPrivate" BOOLEAN NOT NULL DEFAULT false;
-
--- CreateIndex
+-- AlterTable (add private teams)
+ALTER TABLE "team" ADD COLUMN "inviteCode" TEXT,
+ADD COLUMN "inviteCodeHash" TEXT,
+ADD COLUMN "isPrivate" BOOLEAN NOT NULL DEFAULT false;
+-- CreateIndex (encrypted invite key should be unique)
 CREATE UNIQUE INDEX "team_inviteCode_key" ON "team"("inviteCode");
-
--- CreateIndex
+-- CreateIndex (hashed invite keys should be unique)
 CREATE UNIQUE INDEX "team_inviteCodeHash_key" ON "team"("inviteCodeHash");
+
+-- DropIndex (since @id already covers unique)
+DROP INDEX "account_account_id";
+
+-- Create indexes to better cover sorted calls at get data functions and faster queries
+-- CreateIndex
+CREATE INDEX "event_teamId_idx" ON "event"("teamId");
+-- CreateIndex
+CREATE INDEX "event_classId_isPinned_startDate_idx" ON "event"("classId", "isPinned", "startDate");
+-- CreateIndex
+CREATE INDEX "homework_teamId_idx" ON "homework"("teamId");
+-- CreateIndex
+CREATE INDEX "homework_classId_isPinned_submissionDate_idx" ON "homework"("classId", "isPinned", "submissionDate");
+-- CreateIndex
+CREATE INDEX "lesson_teamId_idx" ON "lesson"("teamId");
+-- CreateIndex
+CREATE INDEX "upload_teamId_idx" ON "upload"("teamId");
+-- CreateIndex
+CREATE INDEX "upload_classId_teamId_createdAt_idx" ON "upload"("classId", "teamId", "createdAt");
+-- CreateIndex
+CREATE INDEX "upload_status_createdAt_idx" ON "upload"("status", "createdAt");
+-- CreateIndex
+CREATE INDEX "uploadRequest_teamId_idx" ON "uploadRequest"("teamId");

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 }
 
 model Account {
-  accountId     Int             @id @unique(map: "account_account_id") @default(autoincrement()) @map("accountId")
+  accountId     Int             @id @default(autoincrement()) @map("accountId")
   username      String
   password      String
   deletedAt     BigInt?
@@ -52,6 +52,8 @@ model Event {
   Class       Class     @relation(fields: [classId], references: [classId], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([classId])
+  @@index([teamId])
+  @@index([classId, isPinned, startDate])
   @@map("event")
 }
 
@@ -116,6 +118,8 @@ model Homework {
   Class          Class           @relation(fields: [classId], references: [classId], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([classId])
+  @@index([teamId])
+  @@index([classId, isPinned, submissionDate])
   @@map("homework")
 }
 
@@ -176,6 +180,7 @@ model Lesson {
   Class        Class  @relation(fields: [classId], references: [classId], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([classId])
+  @@index([teamId])
   @@unique([classId, teamId, weekDay, lessonNumber, subjectId])
   @@map("lesson")
 }
@@ -248,6 +253,9 @@ model Upload {
   Class               Class      @relation(fields: [classId], references: [classId], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([classId])
+  @@index([teamId])
+  @@index([classId, teamId, createdAt])
+  @@index([status, createdAt])
   @@map("upload")
 }
 
@@ -260,5 +268,6 @@ model uploadRequest {
   Class               Class      @relation(fields: [classId], references: [classId], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([classId])
+  @@index([teamId])
   @@map("uploadRequest")
 }

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -201,6 +201,9 @@ model Team {
   teamId      Int           @id @default(autoincrement()) @map("teamId")
   classId     Int
   name        String
+  isPrivate   Boolean       @default(false)
+  inviteCode  String?       @unique
+  inviteCodeHash String?    @unique
   createdAt   BigInt?
 
   JoinedTeams JoinedTeams[]

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -74,6 +74,7 @@ model Class {
   classId                 Int           @id @default(autoincrement()) @map("classId")
   className               String
   classCode               String        @unique
+  classCodeHash           String?       @unique // this will be made non-nullable after migration
   createdAt               BigInt
   isTestClass             Boolean
   defaultPermissionLevel  Int

--- a/backend/src/routes/team.route.ts
+++ b/backend/src/routes/team.route.ts
@@ -2,10 +2,17 @@ import express from "express";
 import rateLimit from "express-rate-limit";
 import teamsController from "../controllers/team.controller";
 import checkAccess from "../middleware/access.middleware";
-import { setJoinedTeamsSchema, setTeamsSchema } from "../schemas/team.schema";
+import { 
+  addPrivateTeamSchema, 
+  deletePrivateTeamSchema,
+  joinPrivateTeamSchema, 
+  leavePrivateTeamSchema,
+  setJoinedTeamsSchema, 
+  setTeamsSchema 
+} from "../schemas/team.schema";
 import { validate } from "../middleware/validation.middleware";
 
-// rate limiter
+// team rate limiter
 const teamLimiter = rateLimit({
   windowMs: 1000, // 1 second
   limit: 15, // Max 15 requests per IP per second
@@ -16,9 +23,23 @@ const teamLimiter = rateLimit({
 
 const router = express.Router();
 
+// get public and private teams (if logged in) data: teamId, name, isPrivate, inviteCode (decrypted)
 router.get("/get_teams_data", teamLimiter, checkAccess(["CLASS"]), teamsController.getTeams);
+// set only public teams data (name, manager required)
 router.post("/set_teams_data", teamLimiter, checkAccess(["CLASS", "MANAGER"]), validate(setTeamsSchema), teamsController.setTeams);
+// get all (public and private) joined teams ids (for logged in users)
 router.get("/get_joined_teams_data", teamLimiter, checkAccess(["CLASS", "ACCOUNT"]), teamsController.getJoinedTeams);
+// set only joined public teams (for logged in users)
 router.post("/set_joined_teams_data", teamLimiter, checkAccess(["CLASS", "ACCOUNT"]), validate(setJoinedTeamsSchema), teamsController.setJoinedTeams);
+// add private team (for logged in users)
+router.post("/add_private_team", teamLimiter, checkAccess(["CLASS", "ACCOUNT"]), validate(addPrivateTeamSchema), teamsController.addPrivateTeam);
+// join private team (for logged in users)
+router.post("/join_private_team", teamLimiter, checkAccess(["CLASS", "ACCOUNT"]), validate(joinPrivateTeamSchema), teamsController.joinPrivateTeam);
+// delete private team (for logged in users)
+// eslint-disable-next-line max-len
+router.post("/delete_private_team", teamLimiter, checkAccess(["CLASS", "ACCOUNT"]), validate(deletePrivateTeamSchema), teamsController.deletePrivateTeam);
+// leave private team (for logged in users)
+// eslint-disable-next-line max-len
+router.post("/leave_private_team", teamLimiter, checkAccess(["CLASS", "ACCOUNT"]), validate(leavePrivateTeamSchema), teamsController.leavePrivateTeam);
 
 export default router;

--- a/backend/src/schemas/account.schema.ts
+++ b/backend/src/schemas/account.schema.ts
@@ -62,14 +62,6 @@ export const checkUsernameSchema = z.object({
   })
 });
 
-
-export type registerAccountType = z.infer<typeof registerAccountSchema>;
-export type loginAccountType = z.infer<typeof loginAccountSchema>;
-export type deleteAccountType = z.infer<typeof deleteAccountSchema>;
-export type changeUsernameType = z.infer<typeof changeUsernameSchema>;
-export type changePasswordType = z.infer<typeof changePasswordSchema>;
-export type checkUsernameType = z.infer<typeof checkUsernameSchema>;
-
 export type registerAccountTypeBody = z.infer<typeof registerAccountSchema>["body"];
 export type loginAccountTypeBody = z.infer<typeof loginAccountSchema>["body"];
 export type deleteAccountTypeBody = z.infer<typeof deleteAccountSchema>["body"];

--- a/backend/src/schemas/class.schema.ts
+++ b/backend/src/schemas/class.schema.ts
@@ -74,14 +74,6 @@ export const changeClassNameSchema = z.object({
   })
 });
 
-export type createClassType = z.infer<typeof createClassSchema>;
-export type joinClassType = z.infer<typeof joinClassSchema>;
-export type changeDefaultPermissionType = z.infer<typeof changeDefaultPermissionSchema>;
-export type setClassMembersPermissionsType = z.infer<typeof setClassMembersPermissionsSchema>;
-export type kickClassMembersType = z.infer<typeof kickClassMembersSchema>;
-export type updateDSBMobileDataType = z.infer<typeof updateDSBMobileDataSchema>;
-export type changeClassNameType = z.infer<typeof changeClassNameSchema>;
-
 export type createClassTypeBody = z.infer<typeof createClassSchema>["body"];
 export type joinClassTypeBody = z.infer<typeof joinClassSchema>["body"];
 export type changeDefaultPermissionTypeBody = z.infer<typeof changeDefaultPermissionSchema>["body"];

--- a/backend/src/schemas/event.schema.ts
+++ b/backend/src/schemas/event.schema.ts
@@ -66,13 +66,6 @@ export const setEventTypesSchema = z.object({
   })
 });
 
-
-export type addEventType = z.infer<typeof addEventSchema>;
-export type editEventType = z.infer<typeof editEventSchema>;
-export type deleteEventType = z.infer<typeof deleteEventSchema>;
-export type setEventTypesType = z.infer<typeof setEventTypesSchema>;
-export type pinEventType = z.infer<typeof pinEventSchema>;
-
 export type addEventTypeBody = z.infer<typeof addEventSchema>["body"];
 export type editEventTypeBody = z.infer<typeof editEventSchema>["body"];
 export type deleteEventTypeBody = z.infer<typeof deleteEventSchema>["body"];

--- a/backend/src/schemas/homework.schema.ts
+++ b/backend/src/schemas/homework.schema.ts
@@ -29,7 +29,6 @@ export const deleteHomeworkSchema = z.object({
   })
 });
 
-
 export const editHomeworkSchema = z.object({
   params: z.object({}),
   query: z.object({}),
@@ -51,13 +50,6 @@ export const pinHomeworkSchema = z.object({
     pinStatus: z.boolean()
   })
 });
-
-
-export type addHomeworkType = z.infer<typeof addHomeworkSchema>;
-export type checkHomeworkType = z.infer<typeof checkHomeworkSchema>;
-export type deleteHomeworkType = z.infer<typeof deleteHomeworkSchema>;
-export type editHomeworkType = z.infer<typeof editHomeworkSchema>;
-export type pinHomeworkType = z.infer<typeof pinHomeworkSchema>;
 
 export type addHomeworkTypeBody = z.infer<typeof addHomeworkSchema>["body"];
 export type checkHomeworkTypeBody = z.infer<typeof checkHomeworkSchema>["body"];

--- a/backend/src/schemas/lesson.schema.ts
+++ b/backend/src/schemas/lesson.schema.ts
@@ -18,6 +18,4 @@ export const setLessonDataSchema = z.object({
   })
 });
 
-export type setLessonDataType = z.infer<typeof setLessonDataSchema>;
-
 export type setLessonDataTypeBody = z.infer<typeof setLessonDataSchema>["body"];

--- a/backend/src/schemas/subject.schema.ts
+++ b/backend/src/schemas/subject.schema.ts
@@ -19,6 +19,4 @@ export const setSubjectsSchema = z.object({
   })
 });
 
-export type setSubjectsType = z.infer<typeof setSubjectsSchema>;
-
 export type setSubjectsTypeBody = z.infer<typeof setSubjectsSchema>["body"];

--- a/backend/src/schemas/team.schema.ts
+++ b/backend/src/schemas/team.schema.ts
@@ -21,8 +21,41 @@ export const setJoinedTeamsSchema = z.object({
   })
 });
 
-export type setJoinedTeamsType = z.infer<typeof setJoinedTeamsSchema>;
-export type setTeamsType = z.infer<typeof setTeamsSchema>;
+export const addPrivateTeamSchema = z.object({
+  params: z.object({}),
+  query: z.object({}),
+  body: strictObject({
+    name: z.string().trim().min(1).max(256)
+  })
+});
+
+export const joinPrivateTeamSchema = z.object({
+  params: z.object({}),
+  query: z.object({}),
+  body: strictObject({
+    inviteCode: z.string().trim().min(1).max(256)
+  })
+});
+
+export const deletePrivateTeamSchema = z.object({
+  params: z.object({}),
+  query: z.object({}),
+  body: strictObject({
+    teamId: z.coerce.number()
+  })
+});
+
+export const leavePrivateTeamSchema = z.object({
+  params: z.object({}),
+  query: z.object({}),
+  body: strictObject({
+    teamId: z.coerce.number()
+  })
+});
 
 export type setJoinedTeamsTypeBody = z.infer<typeof setJoinedTeamsSchema>["body"];
 export type setTeamsTypeBody = z.infer<typeof setTeamsSchema>["body"];
+export type addPrivateTeamTypeBody = z.infer<typeof addPrivateTeamSchema>["body"];
+export type joinPrivateTeamTypeBody = z.infer<typeof joinPrivateTeamSchema>["body"];
+export type deletePrivateTeamTypeBody = z.infer<typeof deletePrivateTeamSchema>["body"];
+export type leavePrivateTeamTypeBody = z.infer<typeof leavePrivateTeamSchema>["body"];

--- a/backend/src/schemas/upload.schema.ts
+++ b/backend/src/schemas/upload.schema.ts
@@ -73,10 +73,6 @@ export const deleteUploadRequestSchema = z.object({
 });
 
 export type getUploadFileType = z.infer<typeof getUploadFileSchema>;
-export type editUploadType = z.infer<typeof editUploadSchema>;
-export type deleteUploadType = z.infer<typeof deleteUploadSchema>;
-export type addUploadRequestType = z.infer<typeof addUploadRequestSchema>;
-export type deleteUploadRequestType = z.infer<typeof deleteUploadRequestSchema>;
 
 export type uploadFileTypeBody = z.infer<typeof uploadFileSchema>["body"];
 export type editUploadTypeBody = z.infer<typeof editUploadSchema>["body"];

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,9 @@
+import * as dotenv from "dotenv";
 dotenv.config();
 import { createServer } from "http";
 import path from "path";
 import connectPgSimple from "connect-pg-simple";
 import cron from "node-cron";
-import * as dotenv from "dotenv";
 import express, { Request, Response } from "express";
 import { rateLimit } from "express-rate-limit";
 import session from "express-session";

--- a/backend/src/services/account.service.ts
+++ b/backend/src/services/account.service.ts
@@ -121,7 +121,7 @@ export default {
         data: {
           username,
           password: hashedPassword,
-          createdAt: Date.now()
+          createdAt: BigInt(Date.now())
         }
       });
 
@@ -131,7 +131,7 @@ export default {
             accountId: newAccount.accountId,
             classId: parseInt(session.classId),
             permissionLevel: 0, // assume lowest role for class
-            createdAt: Date.now()
+            createdAt: BigInt(Date.now())
           }
         });
       }
@@ -194,12 +194,31 @@ export default {
       }
     });
     if (joinedClassExists === null && session.classId) {
+      // find if class exists
+      const classIdNum = parseInt(session.classId, 10);
+      const classInfo = await prisma.class.findUnique({
+        where: { classId: classIdNum },
+        select: { defaultPermissionLevel: true }
+      });
+
+      if (!classInfo) {
+        delete session.classId;
+        const err: RequestError = {
+          name: "Not Found",
+          status: 404,
+          message: "Selected class no longer exists",
+          expected: true
+        };
+        throw err;
+      }
+      
+      // create joinedClass entry if class exists
       await prisma.joinedClass.create({
         data: {
           accountId: accountId,
-          classId: parseInt(session.classId),
-          permissionLevel: 0, // assume lowest level
-          createdAt: Date.now()
+          classId: classIdNum,
+          permissionLevel: classInfo.defaultPermissionLevel,
+          createdAt: BigInt(Date.now())
         }
       });
     }
@@ -253,7 +272,7 @@ export default {
           accountId: account!.accountId
         },
         data: {
-          deletedAt: Date.now()
+          deletedAt: BigInt(Date.now())
         }
       });
       // delete related records in JoinedClass, JoinedTeams, and HomeworkCheck

--- a/backend/src/services/class.service.ts
+++ b/backend/src/services/class.service.ts
@@ -1,13 +1,12 @@
 import { RequestError } from "../@types/requestError";
 import { Session, SessionData } from "express-session";
 import { default as prisma } from "../config/prisma";
-import { BigIntreplacer, invalidateCache } from "../utils/validate.functions";
+import { BigIntreplacer, invalidateCache, generateRandomBase62String } from "../utils/validate.functions";
 import { sessionPool } from "../config/pg";
 import logger from "../config/logger";
 import { redisClient } from "../config/redis";
 import fs from "fs/promises";
 import path from "path";
-import { randomInt } from "crypto";
 import { FINAL_UPLOADS_DIR } from "../config/upload";
 import { encryptionManager } from "../utils/encryption.manager";
 import {
@@ -21,22 +20,26 @@ import {
 } from "../schemas/class.schema";
 import socketIO, { SOCKET_EVENTS } from "../config/socket";
 
-const BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-
-function generateRandomBase62String(length = 20): string {
-  let result = "";
-  for (let i = 0; i < length; i++) {
-    result += BASE62[randomInt(0, BASE62.length)];
-  }
-  return result;
-}
-
 const classService = {
   async getClassInfo(session: Session & Partial<SessionData>) {
     // checkAcces.checkClass middleware
     const classInfo = await prisma.class.findUnique({
       where: {
         classId: parseInt(session.classId!)
+      },
+      select: {
+        classId: true,
+        classCode: true,
+        className: true,
+        createdAt: true,
+        isTestClass: true,
+        defaultPermissionLevel: true,
+        storageUsedBytes: true,
+        storageQuotaBytes: true,
+        dsbMobileActivated: true,
+        dsbMobileUser: true,
+        dsbMobilePassword: true,
+        dsbMobileClass: true
       }
     });
     if (!classInfo) {

--- a/backend/src/services/class.service.ts
+++ b/backend/src/services/class.service.ts
@@ -164,16 +164,14 @@ const classService = {
           });
         }
 
-        const migrated = await tx.class.findUnique({
-          where: { classCodeHash: classCodeHash }
-        });
-        if (migrated) {
-          return migrated;
-        }
-
-        return await tx.class.findUnique({
-          where: { classCode: classCode }
-        });
+        return (
+          (await tx.class.findUnique({
+            where: { classCodeHash: classCodeHash }
+          })) ??
+          (await tx.class.findUnique({
+            where: { classCode: classCode }
+          }))
+        );
       });
     }
     if (!targetClass) {

--- a/backend/src/services/class.service.ts
+++ b/backend/src/services/class.service.ts
@@ -121,7 +121,7 @@ const classService = {
       const err: RequestError = {
         name: "Bad Request",
         status: 400,
-        message: "Invalid class code",
+        message: "Invalid class code (starting with encryption prefix)",
         expected: true
       };
       throw err;
@@ -136,31 +136,45 @@ const classService = {
       throw err;
     }
     // try to find class by hash
-    const encryptedClassCode = encryptionManager.encrypt(classCode);
     const classCodeHash = encryptionManager.hash(classCode);
     let targetClass = await prisma.class.findUnique({
       where: {
         classCodeHash: classCodeHash
       }
     });
-    // if not found, search with non-encrypted value 
+    // if not found, search with non-encrypted value
     if (!targetClass) {
-      targetClass = await prisma.class.findUnique({
-        where: {
-          classCode: classCode
-        }
-      });
-      // if found, encrypt the code and update with encrypted class code
-      if (targetClass && !encryptionManager.isEncrypted(targetClass.classCode)) {
-        await prisma.class.update({
-          where: { classId: targetClass.classId },
+      // Use transaction and idempotent update to prevent race conditions during migration
+      targetClass = await prisma.$transaction(async tx => {
+        const encryptedClassCode = encryptionManager.encrypt(classCode);
+        const updateResult = await tx.class.updateMany({
+          where: {
+            classCode: classCode,
+            classCodeHash: null
+          },
           data: {
             classCode: encryptedClassCode,
             classCodeHash: classCodeHash
           }
         });
-        targetClass = { ...targetClass, classCode: encryptedClassCode };
-      }
+
+        if (updateResult.count > 0) {
+          return await tx.class.findUnique({
+            where: { classCodeHash: classCodeHash }
+          });
+        }
+
+        const migrated = await tx.class.findUnique({
+          where: { classCodeHash: classCodeHash }
+        });
+        if (migrated) {
+          return migrated;
+        }
+
+        return await tx.class.findUnique({
+          where: { classCode: classCode }
+        });
+      });
     }
     if (!targetClass) {
       const err: RequestError = {
@@ -583,18 +597,11 @@ const classService = {
       code = generateRandomBase62String();
       const encryptedCode = encryptionManager.encrypt(code);
       const classCodeHash = encryptionManager.hash(code);
-      let exists = await prisma.class.findUnique({
+      const exists = await prisma.class.findUnique({
         where: {
           classCodeHash: classCodeHash
         }
       });
-      if (!exists) {
-        exists = await prisma.class.findUnique({
-          where: {
-            classCode: code
-          }
-        });
-      }
       if (!exists) {
         await prisma.class.update({
           where: {

--- a/backend/src/services/class.service.ts
+++ b/backend/src/services/class.service.ts
@@ -1,4 +1,5 @@
 import { RequestError } from "../@types/requestError";
+import { Prisma } from "@prisma/client";
 import { Session, SessionData } from "express-session";
 import { default as prisma } from "../config/prisma";
 import { BigIntreplacer, invalidateCache, generateRandomBase62String } from "../utils/validate.functions";
@@ -78,8 +79,7 @@ const classService = {
     session: Session & Partial<SessionData>
   ) {
     const { classDisplayName, isTestClass } = reqData;
-    const classCode = generateRandomBase62String();
-
+    // reject if user is already in a class
     if (session.classId) {
       const err: RequestError = {
         name: "Forbidden",
@@ -89,49 +89,74 @@ const classService = {
       };
       throw err;
     }
-
-    const encryptedClassCode = encryptionManager.encrypt(classCode);
-    const classCodeHash = encryptionManager.hash(classCode);
-    const baseData = {
-      className: classDisplayName,
-      classCode: encryptedClassCode,
-      classCodeHash: classCodeHash,
-      createdAt: Date.now(),
-      isTestClass: isTestClass,
-      dsbMobileActivated: false,
-      storageQuotaBytes: isTestClass ? 20 * 1024 * 1024 : 1 * 1024 * 1024 * 1024, // 20MB (test class) or 1 GB (normal class)
-      storageUsedBytes: 0,
-      defaultPermissionLevel: 0 // default setting when creating class is 0 - member status
-    };
-    try {
-      return await prisma.$transaction(async tx => {
-        const createdClass = await tx.class.create({
-          data: baseData
-        });
-        session.classId = createdClass.classId.toString();
-
-        // add user to classJoined table
-        // change permission of user which created the account to admin
-        await tx.joinedClass.create({
-          data: {
-            accountId: session.account!.accountId,
-            classId: createdClass.classId,
-            permissionLevel: 3, // class creator is admin
-            createdAt: Date.now()
-          }
-        });
-        return classCode;
+    // create class with retry attempt fallback
+    const maxAttempts = 10;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const classCode = generateRandomBase62String();
+      const encryptedClassCode = encryptionManager.encrypt(classCode);
+      const classCodeHash = encryptionManager.hash(classCode);
+      // find already existing class with this hash and reject if present
+      const exists = await prisma.class.findUnique({
+        where: { classCodeHash }
       });
-    }
-    catch {
-      const err: RequestError = {
-        name: "Internal Server Error",
-        status: 500,
-        message: "Could not create class in database, please try again",
-        expected: true
+      if (exists) {
+        continue;
+      }
+
+      const baseData = {
+        className: classDisplayName,
+        classCode: encryptedClassCode,
+        classCodeHash: classCodeHash,
+        createdAt: BigInt(Date.now()),
+        isTestClass: isTestClass,
+        dsbMobileActivated: false,
+        storageQuotaBytes: isTestClass ? 20 * 1024 * 1024 : 1 * 1024 * 1024 * 1024, // 20MB (test class) or 1 GB (normal class)
+        storageUsedBytes: 0,
+        defaultPermissionLevel: 0 // default setting when creating class is 0 - member status
       };
-      throw err;
+      // create class and joinedClass entry
+      try {
+        return await prisma.$transaction(async tx => {
+          const createdClass = await tx.class.create({
+            data: baseData
+          });
+          session.classId = createdClass.classId.toString();
+
+          // add user to classJoined table
+          // change permission of user which created the account to admin
+          await tx.joinedClass.create({
+            data: {
+              accountId: session.account!.accountId,
+              classId: createdClass.classId,
+              permissionLevel: 3, // class creator is admin
+              createdAt: BigInt(Date.now())
+            }
+          });
+          return classCode;
+        });
+      }
+      catch (err) {
+        if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+          // unique constraint collision, retry
+          continue;
+        }
+        const reqErr: RequestError = {
+          name: "Internal Server Error",
+          status: 500,
+          message: "Could not create class in database, please try again",
+          expected: true
+        };
+        throw reqErr;
+      }
     }
+    // return generic error instead
+    const err: RequestError = {
+      name: "Server Error",
+      status: 500,
+      message: "Could not generate unique class code",
+      expected: false
+    };
+    throw err;
   },
   async joinClass(reqData: joinClassTypeBody, session: Session & Partial<SessionData>) {
     const { classCode } = reqData;
@@ -222,14 +247,6 @@ const classService = {
             };
             throw err;
           }
-
-          // DB and target class match, but session was out of sync
-          await tx.joinedClass.update({
-            where: { accountId },
-            data: {
-              permissionLevel: targetClass.defaultPermissionLevel
-            }
-          });
         }
         else {
           await tx.joinedClass.create({
@@ -237,7 +254,7 @@ const classService = {
               accountId: accountId,
               classId: targetClass.classId,
               permissionLevel: targetClass.defaultPermissionLevel,
-              createdAt: Date.now()
+              createdAt: BigInt(Date.now())
             }
           });
         }
@@ -314,10 +331,11 @@ const classService = {
         await invalidateCache("UPLOADMETADATA", classUserEntry.classId.toString());
       });
     }
-
+    // avoid class:undefined when sending socket event
+    const classId = session.classId;
     delete session.classId;
     const io = socketIO.getIO();
-    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.MEMBERS);
+    io.to(`class:${classId}`).emit(SOCKET_EVENTS.MEMBERS);
   },
   async deleteClass(session: Session & Partial<SessionData>) {
     await prisma.$transaction(async tx => {

--- a/backend/src/services/class.service.ts
+++ b/backend/src/services/class.service.ts
@@ -48,9 +48,24 @@ const classService = {
       };
       throw err;
     }
+    let decryptedClassCode: string;
+    try {
+      decryptedClassCode = encryptionManager.decrypt(classInfo.classCode);
+    }
+    catch {
+      const err: RequestError = {
+        name: "Bad Request",
+        status: 400,
+        message:
+          "Failed to decrypt class code. The stored value may be corrupted or encrypted with a different key.",
+        expected: true
+      };
+      throw err;
+    }
+
     const decryptedClassInfo = {
       ...classInfo,
-      classCode: encryptionManager.decrypt(classInfo.classCode)
+      classCode: decryptedClassCode
     };
     return JSON.parse(JSON.stringify(decryptedClassInfo, BigIntreplacer));
   },

--- a/backend/src/services/class.service.ts
+++ b/backend/src/services/class.service.ts
@@ -9,6 +9,7 @@ import fs from "fs/promises";
 import path from "path";
 import { randomInt } from "crypto";
 import { FINAL_UPLOADS_DIR } from "../config/upload";
+import { encryptionManager } from "../utils/encryption.manager";
 import {
   changeClassNameTypeBody,
   changeDefaultPermissionTypeBody,
@@ -47,7 +48,11 @@ const classService = {
       };
       throw err;
     }
-    return JSON.parse(JSON.stringify(classInfo, BigIntreplacer));
+    const decryptedClassInfo = {
+      ...classInfo,
+      classCode: encryptionManager.decrypt(classInfo.classCode)
+    };
+    return JSON.parse(JSON.stringify(decryptedClassInfo, BigIntreplacer));
   },
 
   async createClass(
@@ -67,9 +72,12 @@ const classService = {
       throw err;
     }
 
+    const encryptedClassCode = encryptionManager.encrypt(classCode);
+    const classCodeHash = encryptionManager.hash(classCode);
     const baseData = {
       className: classDisplayName,
-      classCode: classCode,
+      classCode: encryptedClassCode,
+      classCodeHash: classCodeHash,
       createdAt: Date.now(),
       isTestClass: isTestClass,
       dsbMobileActivated: false,
@@ -94,7 +102,7 @@ const classService = {
             createdAt: Date.now()
           }
         });
-        return createdClass.classCode;
+        return classCode;
       });
     }
     catch {
@@ -109,6 +117,15 @@ const classService = {
   },
   async joinClass(reqData: joinClassTypeBody, session: Session & Partial<SessionData>) {
     const { classCode } = reqData;
+    if (encryptionManager.isEncrypted(classCode)) {
+      const err: RequestError = {
+        name: "Bad Request",
+        status: 400,
+        message: "Invalid class code",
+        expected: true
+      };
+      throw err;
+    }
     if (session.classId) {
       const err: RequestError = {
         name: "Bad Request",
@@ -118,11 +135,33 @@ const classService = {
       };
       throw err;
     }
-    const targetClass = await prisma.class.findUnique({
+    // try to find class by hash
+    const encryptedClassCode = encryptionManager.encrypt(classCode);
+    const classCodeHash = encryptionManager.hash(classCode);
+    let targetClass = await prisma.class.findUnique({
       where: {
-        classCode: classCode
+        classCodeHash: classCodeHash
       }
     });
+    // if not found, search with non-encrypted value 
+    if (!targetClass) {
+      targetClass = await prisma.class.findUnique({
+        where: {
+          classCode: classCode
+        }
+      });
+      // if found, encrypt the code and update with encrypted class code
+      if (targetClass && !encryptionManager.isEncrypted(targetClass.classCode)) {
+        await prisma.class.update({
+          where: { classId: targetClass.classId },
+          data: {
+            classCode: encryptedClassCode,
+            classCodeHash: classCodeHash
+          }
+        });
+        targetClass = { ...targetClass, classCode: encryptedClassCode };
+      }
+    }
     if (!targetClass) {
       const err: RequestError = {
         name: "Not Found",
@@ -542,18 +581,28 @@ const classService = {
     const maxAttempts = 10;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       code = generateRandomBase62String();
-      const exists = await prisma.class.findUnique({
+      const encryptedCode = encryptionManager.encrypt(code);
+      const classCodeHash = encryptionManager.hash(code);
+      let exists = await prisma.class.findUnique({
         where: {
-          classCode: code
+          classCodeHash: classCodeHash
         }
       });
+      if (!exists) {
+        exists = await prisma.class.findUnique({
+          where: {
+            classCode: code
+          }
+        });
+      }
       if (!exists) {
         await prisma.class.update({
           where: {
             classId: parseInt(session.classId!, 10)
           },
           data: {
-            classCode: code
+            classCode: encryptedCode,
+            classCodeHash: classCodeHash
           }
         });
         const io = socketIO.getIO();

--- a/backend/src/services/event.service.ts
+++ b/backend/src/services/event.service.ts
@@ -3,6 +3,7 @@ import { redisClient, cacheExpiration, CACHE_KEY_PREFIXES, generateCacheKey } fr
 import socketIO, { SOCKET_EVENTS } from "../config/socket";
 import sass from "sass";
 import { default as prisma } from "../config/prisma";
+import { Prisma } from "@prisma/client";
 import {
   isValidColor,
   isValidTeamId,
@@ -69,23 +70,48 @@ export const eventService = {
   async pinEvent(reqData: pinEventTypeBody, session: Session & Partial<SessionData>) {
     const { eventId, pinStatus } = reqData;
 
-    const updated = await prisma.event.updateMany({
+    const existingEvent = await prisma.event.findFirst({
       where: {
         eventId: eventId,
         classId: parseInt(session.classId!, 10)
       },
-      data: {
-        isPinned: pinStatus
+      select: {
+        teamId: true
       }
     });
 
-    if (updated.count === 0) {
+    if (!existingEvent) {
       const err: RequestError = {
         name: "Not Found",
         status: 404,
         message: "Event not found",
         expected: true
       };
+      throw err;
+    }
+
+    await isValidTeamId(existingEvent.teamId, session);
+
+    try {
+      await prisma.event.update({
+        where: {
+          eventId: eventId
+        },
+        data: {
+          isPinned: pinStatus
+        }
+      });
+    }
+    catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
+        const reqErr: RequestError = {
+          name: "Not Found",
+          status: 404,
+          message: "Event not found",
+          expected: true
+        };
+        throw reqErr;
+      }
       throw err;
     }
 
@@ -114,7 +140,7 @@ export const eventService = {
           lesson: lesson,
           endDate: endDate,
           teamId: teamId,
-          createdAt: Date.now()
+          createdAt: BigInt(Date.now())
         }
       });
     }
@@ -292,7 +318,7 @@ export const eventService = {
               classId,
               name: eventType.name,
               color: eventType.color,
-              createdAt: Date.now()
+              createdAt: BigInt(Date.now())
             }
           });
         }

--- a/backend/src/services/event.service.ts
+++ b/backend/src/services/event.service.ts
@@ -6,6 +6,7 @@ import { default as prisma } from "../config/prisma";
 import {
   isValidColor,
   isValidTeamId,
+  getAccessibleTeamIds,
   lessonDateEventAtLeastOneNull,
   updateCacheData,
   BigIntreplacer,
@@ -19,19 +20,22 @@ import { addEventTypeBody, deleteEventTypeBody, editEventTypeBody, setEventTypes
 const inFlightStyleBuild = new Map<number, Promise<string>>();
 
 export const eventService = {
+  // get event data for all users
   async getEventData(session: Session & Partial<SessionData>) {
     // get cache key from class to fetch from cache
     const getEventDataCacheKey = generateCacheKey(CACHE_KEY_PREFIXES.EVENT, session.classId!);
-
     const cachedEventData = await redisClient.get(getEventDataCacheKey);
 
     if (cachedEventData) {
       try {
-        return JSON.parse(cachedEventData);
+        // filter data for private and public teams
+        const cachedData = JSON.parse(cachedEventData) as { teamId: number }[];
+        const accessibleTeamIds = new Set(await getAccessibleTeamIds(session));
+        return cachedData.filter(event => event.teamId === -1 || accessibleTeamIds.has(event.teamId));
       }
       catch (error) {
         logger.error(`Error parsing Redis data: ${error}`);
-        throw new Error();
+        // fall through to prevent crashes and rely on DB
       }
     }
     // no cache data available, fetch from database and update cache
@@ -53,11 +57,13 @@ export const eventService = {
     }
     catch (err) {
       logger.error(`Error updating Redis cache: ${err}`);
-      throw new Error();
+      // fall through to prevent crashes and rely on DB
     }
 
-    const stringified = JSON.stringify(eventData, BigIntreplacer);
-    return JSON.parse(stringified);
+    const accessibleTeamIds = new Set(await getAccessibleTeamIds(session));
+    const filtered = eventData.filter(event => event.teamId === -1 || accessibleTeamIds.has(event.teamId));
+
+    return JSON.parse(JSON.stringify(filtered, BigIntreplacer));
   },
 
   async pinEvent(reqData: pinEventTypeBody, session: Session & Partial<SessionData>) {
@@ -220,7 +226,7 @@ export const eventService = {
       }
       catch (error) {
         logger.error(`Error parsing Redis data: ${error}`);
-        throw new Error();
+        // fall through to prevent crashes and rely on DB
       }
     }
 
@@ -238,7 +244,7 @@ export const eventService = {
     }
     catch (err) {
       logger.error(`Error updating Redis cache: ${err}`);
-      throw new Error();
+      // fall through to prevent crashes and rely on DB
     }
 
     return eventTypeData;
@@ -328,7 +334,7 @@ export const eventService = {
     }
     catch (err) {
       logger.error(`Error updating Redis cache: ${err}`);
-      throw new Error();
+      // fall through to prevent crashes and rely on DB
     }
 
     try {
@@ -354,7 +360,7 @@ export const eventService = {
       }
       catch (error) {
         logger.error(`Error parsing Redis data: ${error}`);
-        throw new Error();
+        // fall through to prevent crashes and rely on DB
       }
     }
 
@@ -451,7 +457,7 @@ export const eventService = {
       }
       catch (err) {
         logger.error(`Error updating Redis cache: ${err}`);
-        throw new Error();
+        // fall through to prevent crashes and rely on DB
       }
 
       return css;

--- a/backend/src/services/homework.service.ts
+++ b/backend/src/services/homework.service.ts
@@ -1,7 +1,7 @@
 import { redisClient, CACHE_KEY_PREFIXES, generateCacheKey } from "../config/redis";
 import socketIO, { SOCKET_EVENTS } from "../config/socket";
 import { default as prisma } from "../config/prisma";
-import { isValidTeamId, BigIntreplacer, updateCacheData, isValidSubjectId, invalidateCache } from "../utils/validate.functions";
+import { getAccessibleTeamIds, isValidTeamId, BigIntreplacer, updateCacheData, isValidSubjectId, invalidateCache } from "../utils/validate.functions";
 import { Session, SessionData } from "express-session";
 import { RequestError } from "../@types/requestError";
 import logger from "../config/logger";
@@ -169,18 +169,22 @@ const homeworkService = {
     const io = socketIO.getIO();
     io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.HOMEWORK);
   },
-
+  // get homework data (for all users)
   async getHomeworkData(session: Session & Partial<SessionData>) {
+    // get cache key and fetch all data from cache
     const getHomeworkDataCacheKey = generateCacheKey(CACHE_KEY_PREFIXES.HOMEWORK, session.classId!);
     const cachedHomeworkData = await redisClient.get(getHomeworkDataCacheKey);
 
     if (cachedHomeworkData) {
       try {
-        return JSON.parse(cachedHomeworkData);
+        // filter data for private and public teams
+        const cachedData = JSON.parse(cachedHomeworkData) as { teamId: number }[];
+        const accessibleTeamIds = new Set(await getAccessibleTeamIds(session));
+        return cachedData.filter(homework => homework.teamId === -1 || accessibleTeamIds.has(homework.teamId));
       }
       catch (error) {
         logger.error(`Error parsing Redis data: ${error}`);
-        throw new Error();
+        // fall through to prevent crashes and rely on DB
       }
     }
 
@@ -199,8 +203,10 @@ const homeworkService = {
 
     await updateCacheData(data, getHomeworkDataCacheKey);
 
-    const stringified = JSON.stringify(data, BigIntreplacer);
-    return JSON.parse(stringified);
+    const accessibleTeamIds = new Set(await getAccessibleTeamIds(session));
+    const filtered = data.filter(homework => homework.teamId === -1 || accessibleTeamIds.has(homework.teamId));
+
+    return JSON.parse(JSON.stringify(filtered, BigIntreplacer));
   },
 
   async pinHomework(reqData: pinHomeworkTypeBody, session: Session & Partial<SessionData>) {

--- a/backend/src/services/homework.service.ts
+++ b/backend/src/services/homework.service.ts
@@ -1,16 +1,17 @@
 import { redisClient, CACHE_KEY_PREFIXES, generateCacheKey } from "../config/redis";
 import socketIO, { SOCKET_EVENTS } from "../config/socket";
 import { default as prisma } from "../config/prisma";
+import { Prisma } from "@prisma/client";
 import { getAccessibleTeamIds, isValidTeamId, BigIntreplacer, updateCacheData, isValidSubjectId, invalidateCache } from "../utils/validate.functions";
 import { Session, SessionData } from "express-session";
 import { RequestError } from "../@types/requestError";
 import logger from "../config/logger";
-import { 
-  addHomeworkTypeBody, 
-  checkHomeworkTypeBody, 
-  deleteHomeworkTypeBody, 
-  editHomeworkTypeBody, 
-  pinHomeworkTypeBody 
+import {
+  addHomeworkTypeBody,
+  checkHomeworkTypeBody,
+  deleteHomeworkTypeBody,
+  editHomeworkTypeBody,
+  pinHomeworkTypeBody
 } from "../schemas/homework.schema";
 
 const homeworkService = {
@@ -31,7 +32,7 @@ const homeworkService = {
           assignmentDate: assignmentDate,
           submissionDate: submissionDate,
           teamId: teamId,
-          createdAt: Date.now()
+          createdAt: BigInt(Date.now())
         }
       });
     }
@@ -60,7 +61,7 @@ const homeworkService = {
 
     const homework = await prisma.homework.findFirst({
       where: { homeworkId, classId },
-      select: { homeworkId: true }
+      select: { homeworkId: true, teamId: true }
     });
 
     if (!homework) {
@@ -73,13 +74,22 @@ const homeworkService = {
       throw err;
     }
 
+    await isValidTeamId(homework.teamId, session);
+
     await prisma.$transaction(async tx => {
-      if (checkStatus === true) {
-        await tx.homeworkCheck.createMany({
-          data: [{ accountId, homeworkId, createdAt: Date.now() }],
-          skipDuplicates: true // prevents race condition P2002 errors
+      if (checkStatus) {
+        await tx.homeworkCheck.upsert({
+          where: {
+            accountId_homeworkId: { accountId, homeworkId }
+          },
+          create: {
+            accountId,
+            homeworkId,
+            createdAt: BigInt(Date.now())
+          },
+          update: {} // no-op update
         });
-      } 
+      }
       else {
         await tx.homeworkCheck.deleteMany({
           where: { accountId, homeworkId }
@@ -127,7 +137,7 @@ const homeworkService = {
     await isValidTeamId(teamId, session);
     try {
       const updated = await prisma.homework.updateMany({
-        where: { 
+        where: {
           homeworkId: homeworkId,
           classId: parseInt(session.classId!, 10)
         },
@@ -193,7 +203,7 @@ const homeworkService = {
         classId: parseInt(session.classId!)
       },
       orderBy: [
-        { isPinned: "desc" }, 
+        { isPinned: "desc" },
         { submissionDate: "asc" },
         { assignmentDate: "asc" },
         { subjectId: "asc" },
@@ -212,23 +222,48 @@ const homeworkService = {
   async pinHomework(reqData: pinHomeworkTypeBody, session: Session & Partial<SessionData>) {
     const { homeworkId, pinStatus } = reqData;
 
-    const updated = await prisma.homework.updateMany({
+    const existingHomework = await prisma.homework.findFirst({
       where: {
         homeworkId: homeworkId,
         classId: parseInt(session.classId!, 10)
       },
-      data: {
-        isPinned: pinStatus
+      select: {
+        teamId: true
       }
     });
 
-    if (updated.count === 0) {
+    if (!existingHomework) {
       const err: RequestError = {
         name: "Not Found",
         status: 404,
         message: "Homework not found",
         expected: true
       };
+      throw err;
+    }
+
+    await isValidTeamId(existingHomework.teamId, session);
+
+    try {
+      await prisma.homework.update({
+        where: {
+          homeworkId: homeworkId
+        },
+        data: {
+          isPinned: pinStatus
+        }
+      });
+    }
+    catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
+        const reqErr: RequestError = {
+          name: "Not Found",
+          status: 404,
+          message: "Homework not found",
+          expected: true
+        };
+        throw reqErr;
+      }
       throw err;
     }
 

--- a/backend/src/services/lesson.service.ts
+++ b/backend/src/services/lesson.service.ts
@@ -2,7 +2,7 @@ import { RequestError } from "../@types/requestError";
 import { CACHE_KEY_PREFIXES, generateCacheKey, redisClient } from "../config/redis";
 import { default as prisma } from "../config/prisma";
 import logger from "../config/logger";
-import { isValidweekDay, BigIntreplacer, updateCacheData, invalidateCache } from "../utils/validate.functions";
+import { getAccessibleTeamIds, isValidweekDay, BigIntreplacer, updateCacheData, invalidateCache } from "../utils/validate.functions";
 import { Session, SessionData } from "express-session";
 import { setLessonDataTypeBody } from "../schemas/lesson.schema";
 import socketIO, { SOCKET_EVENTS } from "../config/socket";
@@ -87,11 +87,13 @@ const lessonService = {
 
     if (cachedLessonData) {
       try {
-        return JSON.parse(cachedLessonData);
+        const cachedData = JSON.parse(cachedLessonData) as { teamId: number }[];
+        const accessibleTeamIds = new Set(await getAccessibleTeamIds(session));
+        return cachedData.filter(lesson => lesson.teamId === -1 || accessibleTeamIds.has(lesson.teamId));
       }
       catch (error) {
         logger.error(`Error parsing Redis cache: ${error}`);
-        throw new Error();
+        // fall through to prevent crashes and rely on DB
       }
     }
 
@@ -110,10 +112,13 @@ const lessonService = {
     }
     catch (err) {
       logger.error(`Error updating Redis cache: ${err}`);
-      throw new Error();
+      // fall through to prevent crashes and rely on DB
     }
 
-    const stringified = JSON.stringify(lessonData, BigIntreplacer);
+    const accessibleTeamIds = new Set(await getAccessibleTeamIds(session));
+    const filtered = lessonData.filter(lesson => lesson.teamId === -1 || accessibleTeamIds.has(lesson.teamId));
+
+    const stringified = JSON.stringify(filtered, BigIntreplacer);
     return JSON.parse(stringified);
   }
 };

--- a/backend/src/services/lesson.service.ts
+++ b/backend/src/services/lesson.service.ts
@@ -2,7 +2,15 @@ import { RequestError } from "../@types/requestError";
 import { CACHE_KEY_PREFIXES, generateCacheKey, redisClient } from "../config/redis";
 import { default as prisma } from "../config/prisma";
 import logger from "../config/logger";
-import { getAccessibleTeamIds, isValidweekDay, BigIntreplacer, updateCacheData, invalidateCache } from "../utils/validate.functions";
+import { 
+  getAccessibleTeamIds, 
+  isValidTeamId, 
+  isValidSubjectId, 
+  isValidweekDay, 
+  BigIntreplacer, 
+  updateCacheData, 
+  invalidateCache 
+} from "../utils/validate.functions";
 import { Session, SessionData } from "express-session";
 import { setLessonDataTypeBody } from "../schemas/lesson.schema";
 import socketIO, { SOCKET_EVENTS } from "../config/socket";
@@ -15,6 +23,8 @@ const lessonService = {
     const { lessons } = reqData;
     for (const lesson of lessons) {
       await isValidweekDay(lesson.weekDay);
+      await isValidTeamId(lesson.teamId, session);
+      await isValidSubjectId(lesson.subjectId, session);
     }
 
     const classId = parseInt(session.classId!, 10);
@@ -58,7 +68,7 @@ const lessonService = {
               room: lesson.room,
               startTime: lesson.startTime,
               endTime: lesson.endTime,
-              createdAt: Date.now()
+              createdAt: BigInt(Date.now())
             }
           });
         }

--- a/backend/src/services/subject.service.ts
+++ b/backend/src/services/subject.service.ts
@@ -19,7 +19,7 @@ const subjectService = {
       }
       catch (error) {
         logger.error(`Error parsing Redis cache: ${error}`);
-        throw new Error();
+        // fall through to prevent crashes and rely on DB
       }
     }
 
@@ -37,7 +37,7 @@ const subjectService = {
     }
     catch (err) {
       logger.error(`Error updating Redis cache: ${err}`);
-      throw new Error();
+      // fall through to prevent crashes and rely on DB
     }
 
     const stringified = JSON.stringify(data, BigIntreplacer);

--- a/backend/src/services/subject.service.ts
+++ b/backend/src/services/subject.service.ts
@@ -115,14 +115,17 @@ const subjectService = {
                 teacherNameLong: subject.teacherNameLong,
                 teacherNameShort: subject.teacherNameShort,
                 teacherNameSubstitution: subject.teacherNameSubstitution ?? [],
-                createdAt: Date.now()
+                createdAt: BigInt(Date.now())
               }
             });
           }
           else {
             dataChanged = true;
-            await tx.subjects.update({
-              where: { subjectId: subject.subjectId },
+            const updated = await tx.subjects.updateMany({
+              where: {
+                subjectId: subject.subjectId,
+                classId: classId
+              },
               data: {
                 subjectNameLong: subject.subjectNameLong,
                 subjectNameShort: subject.subjectNameShort,
@@ -133,6 +136,16 @@ const subjectService = {
                 teacherNameSubstitution: subject.teacherNameSubstitution ?? []
               }
             });
+
+            if (updated.count === 0) {
+              const err: RequestError = {
+                name: "Not Found",
+                status: 404,
+                message: "Subject not found for update",
+                expected: true
+              };
+              throw err;
+            }
           }
         }
         catch {

--- a/backend/src/services/team.service.ts
+++ b/backend/src/services/team.service.ts
@@ -3,49 +3,132 @@ import { RequestError } from "../@types/requestError";
 import { default as prisma } from "../config/prisma";
 import logger from "../config/logger";
 import { CACHE_KEY_PREFIXES, generateCacheKey, redisClient } from "../config/redis";
-import { BigIntreplacer, invalidateCache, updateCacheData } from "../utils/validate.functions";
-import { setJoinedTeamsTypeBody, setTeamsTypeBody } from "../schemas/team.schema";
+import { BigIntreplacer, invalidateCache, updateCacheData, generateRandomBase62String } from "../utils/validate.functions";
+import {
+  addPrivateTeamTypeBody,
+  deletePrivateTeamTypeBody,
+  joinPrivateTeamTypeBody,
+  leavePrivateTeamTypeBody,
+  setJoinedTeamsTypeBody,
+  setTeamsTypeBody
+} from "../schemas/team.schema";
 import fs from "fs/promises";
 import path from "path";
 import { FINAL_UPLOADS_DIR } from "../config/upload";
 import socketIO, { SOCKET_EVENTS } from "../config/socket";
+import { encryptionManager } from "../utils/encryption.manager";
+
+const checkLoggedIn = (session: Session & Partial<SessionData>): boolean => {
+  const accountId = session.account?.accountId;
+  return accountId ? true : false;
+};
 
 const teamService = {
+  // gets all teams data: private and public teams in class - all users
   async getTeamsData(session: Session & Partial<SessionData>) {
-    const getTeamsDataCacheKey = generateCacheKey(CACHE_KEY_PREFIXES.TEAMS, session.classId!);
-    const cachedTeamsData = await redisClient.get(getTeamsDataCacheKey);
+    const classId = Number(session.classId);
+    const cacheKey = generateCacheKey(CACHE_KEY_PREFIXES.TEAMS, classId.toString());
 
-    if (cachedTeamsData) {
-      try {
-        return JSON.parse(cachedTeamsData);
+    const isLoggedIn = checkLoggedIn(session);
+    const accountId = session.account?.accountId;
+
+    const filterTeams = async (
+      teams: {
+        teamId: number;
+        name: string;
+        isPrivate: boolean;
+        inviteCode: string | null;
+      }[]
+      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    ) => {
+      // if not logged in, return all non-private data
+      if (!isLoggedIn) {
+        return teams.filter(t => !t.isPrivate);
       }
-      catch (error) {
-        logger.error(`Error parsing Redis data: ${error}`);
-        throw new Error();
+
+      const joinedTeams = await prisma.joinedTeams.findMany({
+        where: { accountId },
+        select: { teamId: true }
+      });
+      // filter with joinedTeams
+      const joinedIds = new Set(joinedTeams.map(t => t.teamId));
+      return teams.filter(t => !t.isPrivate || joinedIds.has(t.teamId));
+    };
+
+    // Business logic START
+    const cached = await redisClient.get(cacheKey);
+    if (cached) {
+      try {
+        const teams = JSON.parse(cached);
+        return await filterTeams(teams);
+      }
+      catch (err) {
+        logger.error(`Error parsing Redis data: ${err}`);
+        // fall through to prevent crashes and rely on DB
       }
     }
 
-    const data = await prisma.team.findMany({
-      where: {
-        classId: parseInt(session.classId!)
+    // teams data was not found in cache, try DB
+    const teams = await prisma.team.findMany({
+      where: { classId },
+      select: {
+        teamId: true,
+        name: true,
+        isPrivate: true,
+        inviteCode: true
       }
     });
 
+    const processedTeams = teams.map(team => ({
+      ...team,
+      inviteCode:
+        team.isPrivate && team.inviteCode
+          ? encryptionManager.decrypt(team.inviteCode)
+          : null
+    }));
+
+    // update cache (best effort)
     try {
-      await updateCacheData(data, getTeamsDataCacheKey);
+      await updateCacheData(processedTeams, cacheKey);
     }
     catch (err) {
       logger.error(`Error updating Redis data: ${err}`);
-      throw new Error();
+      // fall through to prevent crashes and rely on DB
     }
 
-    const stringified = JSON.stringify(data, BigIntreplacer);
-    return JSON.parse(stringified);
+    const filtered = await filterTeams(processedTeams);
+    // Avoid BigInt serialization issues
+    return JSON.parse(JSON.stringify(filtered, BigIntreplacer));
   },
-
+  // sets public teams data in class (manager only)
   async setTeamsData(reqData: setTeamsTypeBody, session: Session & Partial<SessionData>) {
     const { teams } = reqData;
     const classId = parseInt(session.classId!, 10);
+    // check for any private teams and reject the request if present
+    const teamIds = teams
+      .map(t => t.teamId)
+      .filter((id): id is number => id !== "" && typeof id === "number");
+
+    if (teamIds.length > 0) {
+      const privateTeams = await prisma.team.findMany({
+        where: {
+          classId,
+          teamId: { in: teamIds },
+          isPrivate: true
+        },
+        select: { teamId: true }
+      });
+
+      if (privateTeams.length > 0) {
+        const err: RequestError = {
+          name: "Bad Request",
+          status: 400,
+          message: "Private teams cannot be modified through this route",
+          expected: true
+        };
+        throw err;
+      }
+    }
     // variable to check if cache should be reloaded (e.g. on team deletion)
     let dataChanged = false;
     // track if teams were deleted (affects homework, events, lessons)
@@ -66,7 +149,8 @@ const teamService = {
 
     const existingTeams = await prisma.team.findMany({
       where: {
-        classId: parseInt(session.classId!)
+        classId: parseInt(session.classId!),
+        isPrivate: false
       }
     });
 
@@ -86,7 +170,9 @@ const teamService = {
             for (const upload of uploads) {
               for (const file of upload.Files) {
                 const filePath = path.join(classDir, file.storedFileName);
-                await fs.unlink(filePath).catch(() => { });
+                await fs.unlink(filePath).catch(() => {
+                  logger.error(`File could not be deleted during team deletion, teamId: ${team.teamId}`);
+                });
               }
               // Calculate storage to release
               const sizeToRelease = upload.status === "completed"
@@ -100,6 +186,12 @@ const teamService = {
                 });
               }
             }
+            // Delete all upload requests of this team
+            await tx.uploadRequest.deleteMany({
+              where: {
+                teamId: team.teamId
+              }
+            });
             // Delete file metadata records
             await tx.fileMetadata.deleteMany({
               where: {
@@ -138,22 +230,15 @@ const teamService = {
       );
 
       for (const team of teams) {
-        if (team.name.trim() === "") {
-          const err: RequestError = {
-            name: "Bad Request",
-            status: 400,
-            message: "Invalid data (Team name cannot be empty)",
-            expected: true
-          };
-          throw err;
-        }
         try {
+          // create team if no teamId available
           if (team.teamId === "") {
             dataChanged = true;
             await tx.team.create({
               data: {
                 classId: classId,
                 name: team.name,
+                isPrivate: false,
                 createdAt: Date.now()
               }
             });
@@ -167,7 +252,6 @@ const teamService = {
             await tx.team.update({
               where: { teamId: team.teamId },
               data: {
-                classId: classId,
                 name: team.name
               }
             });
@@ -203,7 +287,7 @@ const teamService = {
       }
     }
   },
-
+  // gets all joined teams id: private and public (logged in users only)
   async getJoinedTeamsData(session: Session & Partial<SessionData>) {
     const accountId = session.account!.accountId;
 
@@ -219,24 +303,154 @@ const teamService = {
 
     return teams;
   },
+  // add/create a private team (and join it) (logged in users only)
+  async addPrivateTeam(reqData: addPrivateTeamTypeBody, session: Session & Partial<SessionData>) {
+    const { name } = reqData;
+    const classId = parseInt(session.classId!, 10);
+    const accountId = session.account!.accountId;
 
+    const inviteCode = generateRandomBase62String();
+    const encryptedInviteCode = encryptionManager.encrypt(inviteCode);
+    const inviteCodeHash = encryptionManager.hash(inviteCode);
+
+    try {
+      const createdTeam = await prisma.$transaction(async tx => {
+        const newTeam = await tx.team.create({
+          data: {
+            classId,
+            name,
+            isPrivate: true,
+            inviteCode: encryptedInviteCode,
+            inviteCodeHash,
+            createdAt: Date.now()
+          }
+        });
+
+        await tx.joinedTeams.create({
+          data: {
+            teamId: newTeam.teamId,
+            accountId,
+            createdAt: Date.now()
+          }
+        });
+
+        return newTeam;
+      });
+
+      await invalidateCache("TEAMS", session.classId!);
+      const io = socketIO.getIO();
+      io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.TEAMS);
+      io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.JOINED_TEAMS);
+
+      return {
+        teamId: createdTeam.teamId,
+        teamName: createdTeam.name,
+        inviteCode
+      };
+    }
+    catch {
+      const err: RequestError = {
+        name: "Bad Request",
+        status: 400,
+        message: "Invalid data format",
+        expected: true
+      };
+      throw err;
+    }
+  },
+  // join private team based on invite code (logged in users only)
+  async joinPrivateTeam(reqData: joinPrivateTeamTypeBody, session: Session & Partial<SessionData>) {
+    const { inviteCode } = reqData;
+    const classId = parseInt(session.classId!, 10);
+    const accountId = session.account!.accountId;
+
+    // reject already encrypted values for safety
+    if (encryptionManager.isEncrypted(inviteCode)) {
+      const err: RequestError = {
+        name: "Bad Request",
+        status: 400,
+        message: "Invalid invite code",
+        expected: true
+      };
+      throw err;
+    }
+
+    // find class through inviteCodeHash
+    const inviteCodeHash = encryptionManager.hash(inviteCode);
+    const targetTeam = await prisma.team.findFirst({
+      where: {
+        classId,
+        inviteCodeHash
+      }
+    });
+
+    if (!targetTeam || !targetTeam.isPrivate) {
+      const err: RequestError = {
+        name: "Not Found",
+        status: 404,
+        message: "Private team not found",
+        expected: true
+      };
+      throw err;
+    }
+    // create new join entry and send socket event
+    await prisma.joinedTeams.create({
+      data: {
+        teamId: targetTeam.teamId,
+        accountId,
+        createdAt: Date.now()
+      }
+    });
+
+    const io = socketIO.getIO();
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.JOINED_TEAMS);
+  },
+  // set joined teams data only for public teams (logged in users only)
   async setJoinedTeamsData(reqData: setJoinedTeamsTypeBody, session: Session & Partial<SessionData>) {
     const { teams } = reqData;
     const accountId = session.account!.accountId;
+    const classId = parseInt(session.classId!, 10);
+
+    const publicTeams = await prisma.team.findMany({
+      where: {
+        classId,
+        teamId: { in: teams },
+        isPrivate: false
+      },
+      select: { teamId: true }
+    });
+    const publicTeamIds = new Set(publicTeams.map(team => team.teamId));
+    const invalidTeams = teams.filter(teamId => !publicTeamIds.has(teamId));
+    if (invalidTeams.length > 0) {
+      const err: RequestError = {
+        name: "Forbidden",
+        status: 403,
+        message: "One or more teams are not public or not accessible",
+        expected: true
+      };
+      throw err;
+    }
 
     await prisma.$transaction(async tx => {
       await tx.joinedTeams.deleteMany({
-        where: { accountId: accountId }
+        where: {
+          accountId,
+          Team: {
+            classId,
+            isPrivate: false
+          }
+        }
       });
 
-      for (const teamId of teams) {
+      if (teams.length > 0) {
         try {
-          await tx.joinedTeams.create({
-            data: {
-              teamId: teamId,
-              accountId: accountId,
+          await tx.joinedTeams.createMany({
+            data: teams.map(teamId => ({
+              teamId,
+              accountId,
               createdAt: Date.now()
-            }
+            })),
+            skipDuplicates: true
           });
         }
         catch {
@@ -250,6 +464,191 @@ const teamService = {
         }
       }
     });
+
+    const io = socketIO.getIO();
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.JOINED_TEAMS);
+  },
+  // delete a private team (logged in users only)
+  async deletePrivateTeam(reqData: deletePrivateTeamTypeBody, session: Session & Partial<SessionData>) {
+    const { teamId } = reqData;
+    const classId = parseInt(session.classId!, 10);
+    const accountId = session.account!.accountId;
+
+    // check for team existence
+    const team = await prisma.team.findUnique({
+      where: { teamId, classId }
+    });
+    if (!team || !team.isPrivate) {
+      const err: RequestError = {
+        name: "Not Found",
+        status: 404,
+        message: "Private team not found",
+        expected: true
+      };
+      throw err;
+    }
+
+    // check for valid membership
+    const isMember = await prisma.joinedTeams.findUnique({
+      where: {
+        teamId_accountId: {
+          teamId: team.teamId,
+          accountId
+        }
+      }
+    });
+    if (!isMember) {
+      const err: RequestError = {
+        name: "Forbidden",
+        status: 403,
+        message: "You are not a member of this private team",
+        expected: true
+      };
+      throw err;
+    }
+
+    await prisma.$transaction(async tx => {
+      //delete all physical files on disk of private team
+      const uploads = await tx.upload.findMany({
+        where: { teamId },
+        include: { Files: true }
+      });
+      const classDir = path.join(FINAL_UPLOADS_DIR, classId.toString());
+      for (const upload of uploads) {
+        for (const file of upload.Files) {
+          const filePath = path.join(classDir, file.storedFileName);
+          await fs.unlink(filePath).catch(() => { });
+        }
+
+        const sizeToRelease = upload.status === "completed"
+          ? BigInt(upload.Files.reduce((sum, file) => sum + file.size, 0))
+          : upload.reservedBytes;
+        if (sizeToRelease > 0n) {
+          await tx.class.update({
+            where: { classId },
+            data: { storageUsedBytes: { decrement: sizeToRelease } }
+          });
+        }
+      }
+      // delete all upload requests of private team
+      await tx.uploadRequest.deleteMany({
+        where: {
+          teamId: team.teamId
+        }
+      });
+      // delete all file metadata of private team
+      await tx.fileMetadata.deleteMany({
+        where: {
+          uploadId: {
+            in: uploads.map(u => u.uploadId)
+          }
+        }
+      });
+      // delete all uploads of private team
+      await tx.upload.deleteMany({
+        where: { teamId }
+      });
+      // delete all homework of private team
+      await tx.homework.deleteMany({
+        where: { teamId }
+      });
+      // delete all events of private team
+      await tx.event.deleteMany({
+        where: { teamId }
+      });
+      // delete all lessons of private team
+      await tx.lesson.deleteMany({
+        where: { teamId }
+      });
+      // delete all joinedTeams data of private team
+      await tx.joinedTeams.deleteMany({
+        where: { teamId }
+      });
+      // delete private team
+      await tx.team.delete({
+        where: { teamId }
+      });
+    });
+
+    await invalidateCache("TEAMS", session.classId!);
+    await invalidateCache("HOMEWORK", session.classId!);
+    await invalidateCache("EVENT", session.classId!);
+    await invalidateCache("LESSON", session.classId!);
+    await invalidateCache("UPLOADMETADATA", session.classId!);
+    await invalidateCache("UPLOADREQUESTS", session.classId!);
+
+    const io = socketIO.getIO();
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.TEAMS);
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.JOINED_TEAMS);
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.HOMEWORK);
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.EVENTS);
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.TIMETABLES);
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.UPLOADS);
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.UPLOAD_REQUESTS);
+  },
+  // leave private team (logged in users only)
+  async leavePrivateTeam(reqData: leavePrivateTeamTypeBody, session: Session & Partial<SessionData>) {
+    const { teamId } = reqData;
+    const classId = parseInt(session.classId!, 10);
+    const accountId = session.account!.accountId;
+
+    // check for team existence
+    const team = await prisma.team.findUnique({
+      where: { teamId, classId }
+    });
+    if (!team || !team.isPrivate) {
+      const err: RequestError = {
+        name: "Not Found",
+        status: 404,
+        message: "Private team not found",
+        expected: true
+      };
+      throw err;
+    }
+
+    // check for valid membership
+    const isMember = await prisma.joinedTeams.findUnique({
+      where: {
+        teamId_accountId: {
+          teamId: team.teamId,
+          accountId
+        }
+      }
+    });
+    if (!isMember) {
+      const err: RequestError = {
+        name: "Forbidden",
+        status: 403,
+        message: "You are not a member of this private team",
+        expected: true
+      };
+      throw err;
+    }
+
+    // check if private team should be deleted instead
+    const membersCount = await prisma.joinedTeams.count({
+      where: { teamId: team.teamId }
+    });
+    if (membersCount <= 1) {
+      const err: RequestError = {
+        name: "Conflict",
+        status: 409,
+        message: "You are the last member. Please delete the private team instead",
+        expected: true
+      };
+      throw err;
+    }
+    await prisma.joinedTeams.delete({
+      where: {
+        teamId_accountId: {
+          teamId: team.teamId,
+          accountId
+        }
+      }
+    });
+
+    const io = socketIO.getIO();
+    io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.JOINED_TEAMS);
   }
 };
 

--- a/backend/src/services/team.service.ts
+++ b/backend/src/services/team.service.ts
@@ -1,4 +1,5 @@
 import { Session, SessionData } from "express-session";
+import { Prisma } from "@prisma/client";
 import { RequestError } from "../@types/requestError";
 import { default as prisma } from "../config/prisma";
 import logger from "../config/logger";
@@ -20,7 +21,7 @@ import { encryptionManager } from "../utils/encryption.manager";
 
 const checkLoggedIn = (session: Session & Partial<SessionData>): boolean => {
   const accountId = session.account?.accountId;
-  return accountId ? true : false;
+  return !!accountId;
 };
 
 const teamService = {
@@ -55,12 +56,44 @@ const teamService = {
       return teams.filter(t => !t.isPrivate || joinedIds.has(t.teamId));
     };
 
+    const decryptInviteCodes = (
+      teams: {
+        teamId: number;
+        name: string;
+        isPrivate: boolean;
+        inviteCode: string | null;
+      }[]
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    ) => teams.map(team => ({
+      ...team,
+      inviteCode:
+        team.isPrivate && team.inviteCode && encryptionManager.isEncrypted(team.inviteCode)
+          ? encryptionManager.decrypt(team.inviteCode)
+          : null
+    }));
+
     // Business logic START
     const cached = await redisClient.get(cacheKey);
     if (cached) {
       try {
-        const teams = JSON.parse(cached);
-        return await filterTeams(teams);
+        const teams = JSON.parse(cached) as {
+          teamId: number;
+          name: string;
+          isPrivate: boolean;
+          inviteCode: string | null;
+        }[];
+
+        const hasPlaintextInviteCodes = teams.some(team =>
+          team.isPrivate && team.inviteCode && !encryptionManager.isEncrypted(team.inviteCode)
+        );
+
+        if (!hasPlaintextInviteCodes) {
+          const filtered = await filterTeams(teams);
+          const decrypted = decryptInviteCodes(filtered);
+          return JSON.parse(JSON.stringify(decrypted, BigIntreplacer));
+        }
+
+        logger.warn("Unsafe cached invite codes detected; ignoring teams cache and reloading from DB.");
       }
       catch (err) {
         logger.error(`Error parsing Redis data: ${err}`);
@@ -79,26 +112,19 @@ const teamService = {
       }
     });
 
-    const processedTeams = teams.map(team => ({
-      ...team,
-      inviteCode:
-        team.isPrivate && team.inviteCode
-          ? encryptionManager.decrypt(team.inviteCode)
-          : null
-    }));
-
     // update cache (best effort)
     try {
-      await updateCacheData(processedTeams, cacheKey);
+      await updateCacheData(teams, cacheKey);
     }
     catch (err) {
       logger.error(`Error updating Redis data: ${err}`);
       // fall through to prevent crashes and rely on DB
     }
 
-    const filtered = await filterTeams(processedTeams);
+    const filtered = await filterTeams(teams);
+    const decrypted = decryptInviteCodes(filtered);
     // Avoid BigInt serialization issues
-    return JSON.parse(JSON.stringify(filtered, BigIntreplacer));
+    return JSON.parse(JSON.stringify(decrypted, BigIntreplacer));
   },
   // sets public teams data in class (manager only)
   async setTeamsData(reqData: setTeamsTypeBody, session: Session & Partial<SessionData>) {
@@ -131,7 +157,7 @@ const teamService = {
     }
     // variable to check if cache should be reloaded (e.g. on team deletion)
     let dataChanged = false;
-    // track if teams were deleted (affects homework, events, lessons)
+    // track if teams were deleted (affects homework, events, lessons, upload (requests))
     let teamsDeleted = false;
 
     // Check for duplicate team names
@@ -170,8 +196,12 @@ const teamService = {
             for (const upload of uploads) {
               for (const file of upload.Files) {
                 const filePath = path.join(classDir, file.storedFileName);
-                await fs.unlink(filePath).catch(() => {
-                  logger.error(`File could not be deleted during team deletion, teamId: ${team.teamId}`);
+                await fs.unlink(filePath).catch(error => {
+                  logger.error(`File could not be deleted during team deletion, 
+                  teamId: ${team.teamId},
+                  path: ${filePath},
+                  error: ${error}`
+                  );
                 });
               }
               // Calculate storage to release
@@ -239,7 +269,7 @@ const teamService = {
                 classId: classId,
                 name: team.name,
                 isPrivate: false,
-                createdAt: Date.now()
+                createdAt: BigInt(Date.now())
               }
             });
           }
@@ -274,16 +304,21 @@ const teamService = {
       await invalidateCache("TEAMS", session.classId!);
       const io = socketIO.getIO();
       io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.TEAMS);
+      io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.JOINED_TEAMS);
 
-      // If teams were deleted, also update homework, events, and lessons caches
+      // If teams were deleted, also update homework, events, lesson and upload (request) caches
       if (teamsDeleted) {
         await invalidateCache("HOMEWORK", session.classId!);
         await invalidateCache("EVENT", session.classId!);
         await invalidateCache("LESSON", session.classId!);
+        await invalidateCache("UPLOADMETADATA", session.classId!);
+        await invalidateCache("UPLOADREQUESTS", session.classId!);
 
         io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.HOMEWORK);
         io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.EVENTS);
         io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.TIMETABLES);
+        io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.UPLOADS);
+        io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.UPLOAD_REQUESTS);
       }
     }
   },
@@ -308,55 +343,69 @@ const teamService = {
     const { name } = reqData;
     const classId = parseInt(session.classId!, 10);
     const accountId = session.account!.accountId;
-
-    const inviteCode = generateRandomBase62String();
-    const encryptedInviteCode = encryptionManager.encrypt(inviteCode);
-    const inviteCodeHash = encryptionManager.hash(inviteCode);
-
-    try {
-      const createdTeam = await prisma.$transaction(async tx => {
-        const newTeam = await tx.team.create({
-          data: {
-            classId,
-            name,
-            isPrivate: true,
-            inviteCode: encryptedInviteCode,
-            inviteCodeHash,
-            createdAt: Date.now()
-          }
-        });
-
-        await tx.joinedTeams.create({
-          data: {
-            teamId: newTeam.teamId,
-            accountId,
-            createdAt: Date.now()
-          }
-        });
-
-        return newTeam;
+    // create private team based on max 10 attempts
+    const maxAttempts = 10;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const inviteCode = generateRandomBase62String();
+      const encryptedInviteCode = encryptionManager.encrypt(inviteCode);
+      const inviteCodeHash = encryptionManager.hash(inviteCode);
+      // check if hash code is unique, if not -> retry
+      const exists = await prisma.team.findUnique({
+        where: { inviteCodeHash }
       });
-
-      await invalidateCache("TEAMS", session.classId!);
-      const io = socketIO.getIO();
-      io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.TEAMS);
-      io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.JOINED_TEAMS);
-
-      return {
-        teamId: createdTeam.teamId,
-        teamName: createdTeam.name,
-        inviteCode
-      };
+      if (exists) {
+        continue;
+      }
+      // create team and joinedTeam entry in transaction
+      try {
+        await prisma.$transaction(async tx => {
+          const newTeam = await tx.team.create({
+            data: {
+              classId,
+              name,
+              isPrivate: true,
+              inviteCode: encryptedInviteCode,
+              inviteCodeHash,
+              createdAt: BigInt(Date.now())
+            }
+          });
+          await tx.joinedTeams.create({
+            data: {
+              teamId: newTeam.teamId,
+              accountId,
+              createdAt: BigInt(Date.now())
+            }
+          });
+        });
+        // invalidate teams cache and resend socket updates
+        await invalidateCache("TEAMS", session.classId!);
+        const io = socketIO.getIO();
+        io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.TEAMS);
+        io.to(`class:${session.classId}`).emit(SOCKET_EVENTS.JOINED_TEAMS);
+        return;
+      }
+      catch (err) {
+        if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+          // unique constraint collision, retry
+          continue;
+        }
+        const reqErr: RequestError = {
+          name: "Bad Request",
+          status: 400,
+          message: "Invalid data format",
+          expected: true
+        };
+        throw reqErr;
+      }
     }
-    catch {
-      const err: RequestError = {
-        name: "Bad Request",
-        status: 400,
-        message: "Invalid data format",
-        expected: true
-      };
-      throw err;
-    }
+    // return generic error otherwise
+    const err: RequestError = {
+      name: "Server Error",
+      status: 500,
+      message: "Could not generate unique invite code",
+      expected: false
+    };
+    throw err;
   },
   // join private team based on invite code (logged in users only)
   async joinPrivateTeam(reqData: joinPrivateTeamTypeBody, session: Session & Partial<SessionData>) {
@@ -394,11 +443,20 @@ const teamService = {
       throw err;
     }
     // create new join entry and send socket event
-    await prisma.joinedTeams.create({
-      data: {
+    await prisma.joinedTeams.upsert({
+      where: {
+        teamId_accountId: {
+          teamId: targetTeam.teamId,
+          accountId
+        }
+      },
+      update: {
+        // do nothing if already exists
+      },
+      create: {
         teamId: targetTeam.teamId,
         accountId,
-        createdAt: Date.now()
+        createdAt: BigInt(Date.now())
       }
     });
 
@@ -448,7 +506,7 @@ const teamService = {
             data: teams.map(teamId => ({
               teamId,
               accountId,
-              createdAt: Date.now()
+              createdAt: BigInt(Date.now())
             })),
             skipDuplicates: true
           });
@@ -508,7 +566,7 @@ const teamService = {
     }
 
     await prisma.$transaction(async tx => {
-      //delete all physical files on disk of private team
+      // delete all physical files on disk of private team
       const uploads = await tx.upload.findMany({
         where: { teamId },
         include: { Files: true }
@@ -517,7 +575,14 @@ const teamService = {
       for (const upload of uploads) {
         for (const file of upload.Files) {
           const filePath = path.join(classDir, file.storedFileName);
-          await fs.unlink(filePath).catch(() => { });
+          await fs.unlink(filePath).catch(error => {
+            logger.error(
+              `File could not be deleted during private team deletion, 
+              teamId: ${team.teamId}, 
+              path: ${filePath},
+              error: ${error}`
+            );
+          });
         }
 
         const sizeToRelease = upload.status === "completed"

--- a/backend/src/services/upload.service.ts
+++ b/backend/src/services/upload.service.ts
@@ -17,14 +17,14 @@ import {
 } from "../schemas/upload.schema";
 import { removeTempFiles } from "../utils/upload.cleanup";
 import { queueJob, QUEUE_KEYS, generateCacheKey, CACHE_KEY_PREFIXES, redisClient } from "../config/redis";
-import { invalidateCache, BigIntreplacer, isValidTeamId, updateCacheData } from "../utils/validate.functions";
+import { getAccessibleTeamIds, invalidateCache, BigIntreplacer, isValidTeamId, updateCacheData } from "../utils/validate.functions";
 import socketIO, { SOCKET_EVENTS } from "../config/socket";
 
 
 type GetUploadFileInput = {
   fileIdParam: number;
   action: getUploadFileType["query"]["action"];
-  classId: string;
+  session: Session & Partial<SessionData>;
 };
 
 type GetUploadFileResult = {
@@ -86,9 +86,26 @@ const getUploadList = async (
     Account: { select: { username: true } };
     Files: true;
   },
-  orderBy: Prisma.UploadOrderByWithRelationInput[]
+  orderBy: Prisma.UploadOrderByWithRelationInput[],
+  teamFilter?: Set<number>
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 ) => {
+  if (teamFilter) {
+    const uploads = await prisma.upload.findMany({
+      where: {
+        classId,
+        OR: [
+          { teamId: -1 },
+          { teamId: { in: Array.from(teamFilter) } }
+        ]
+      },
+      include,
+      orderBy,
+      take: isGetAllData ? undefined : 50
+    });
+    return sortUploads(mapUploadData(uploads));
+  }
+
   if (isGetAllData) {
     const uploads = await prisma.upload.findMany({
       where: { classId },
@@ -201,13 +218,22 @@ const uploadService = {
 
   async getUploadMetadata(isGetAllData: boolean, session: Session & Partial<SessionData>) {
     const classId = parseInt(session.classId!, 10);
+    const accessibleTeamIds = new Set(await getAccessibleTeamIds(session));
 
     const classInformation = await prisma.class.findUnique({
       where: { classId },
       select: { storageUsedBytes: true, storageQuotaBytes: true }
     });
 
-    const totalUploads = await prisma.upload.count({ where: { classId } });
+    const totalUploads = await prisma.upload.count({
+      where: {
+        classId,
+        OR: [
+          { teamId: -1 },
+          { teamId: { in: Array.from(accessibleTeamIds) } }
+        ]
+      }
+    });
 
     if (totalUploads === 0) {
       return {
@@ -231,7 +257,14 @@ const uploadService = {
     ];
 
     const getUploadMetadataCacheKey = generateCacheKey(CACHE_KEY_PREFIXES.UPLOADMETADATA, session.classId!);
-    const uploadList = await getUploadList(classId, isGetAllData, getUploadMetadataCacheKey, include, orderBy);
+    const uploadList = await getUploadList(
+      classId,
+      isGetAllData,
+      getUploadMetadataCacheKey,
+      include,
+      orderBy,
+      accessibleTeamIds
+    );
 
     const hasMore = !isGetAllData && totalUploads > 50;
 
@@ -246,13 +279,15 @@ const uploadService = {
     return JSON.parse(stringified);
   },
 
-  async getUploadFile({ fileIdParam, action, classId }: GetUploadFileInput): Promise<GetUploadFileResult> {
+  async getUploadFile({ fileIdParam, action, session }: GetUploadFileInput): Promise<GetUploadFileResult> {
+    const classId = session.classId!;
     const fileData = await prisma.fileMetadata.findUnique({
       where: { fileMetaDataId: fileIdParam },
       include: {
         Upload: {
           select: {
             classId: true,
+            teamId: true,
             uploadName: true,
             Files: {
               select: { fileMetaDataId: true },
@@ -268,6 +303,18 @@ const uploadService = {
         name: "Not Found",
         status: 404,
         message: "File not found or access denied.",
+        expected: true
+      };
+      throw err;
+    }
+
+    const accessibleTeamIds = new Set(await getAccessibleTeamIds(session));
+
+    if (fileData.Upload.teamId !== -1 && !accessibleTeamIds.has(fileData.Upload.teamId)) {
+      const err: RequestError = {
+        name: "Forbidden",
+        status: 403,
+        message: "You are not allowed to access this upload.",
         expected: true
       };
       throw err;
@@ -588,13 +635,15 @@ const uploadService = {
 
   async getUploadRequests(session: Session & Partial<SessionData>) {
     const classIdNum = parseInt(session.classId!, 10);
+    const accessibleTeamIds = new Set(await getAccessibleTeamIds(session));
 
     const getUploadRequestsCacheKey = generateCacheKey(CACHE_KEY_PREFIXES.UPLOADREQUESTS, session.classId!);
     const cachedData = await redisClient.get(getUploadRequestsCacheKey);
 
     if (cachedData) {
       try {
-        return JSON.parse(cachedData);
+        const parsed = JSON.parse(cachedData) as { teamId: number }[];
+        return parsed.filter(request => request.teamId === -1 || accessibleTeamIds.has(request.teamId));
       }
       catch (error) {
         logger.error(`Error parsing Redis data: ${error}`);
@@ -615,7 +664,8 @@ const uploadService = {
       // Continue without caching
     }
 
-    const stringified = JSON.stringify(uploadRequests, BigIntreplacer);
+    const filteredRequests = uploadRequests.filter(request => request.teamId === -1 || accessibleTeamIds.has(request.teamId));
+    const stringified = JSON.stringify(filteredRequests, BigIntreplacer);
     return JSON.parse(stringified);
   },
 

--- a/backend/src/services/upload.service.ts
+++ b/backend/src/services/upload.service.ts
@@ -90,54 +90,51 @@ const getUploadList = async (
   teamFilter?: Set<number>
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 ) => {
-  if (teamFilter) {
-    const uploads = await prisma.upload.findMany({
-      where: {
-        classId,
-        OR: [
-          { teamId: -1 },
-          { teamId: { in: Array.from(teamFilter) } }
-        ]
-      },
-      include,
-      orderBy,
-      take: isGetAllData ? undefined : 50
-    });
-    return sortUploads(mapUploadData(uploads));
-  }
-
+  let uploadList: UploadListItem[] = [];
+  // if get all metadata flag is set -> get all data from db and sort
+  // cache only caches first 50 metadata items due to storage constraints 
   if (isGetAllData) {
     const uploads = await prisma.upload.findMany({
       where: { classId },
       include,
       orderBy
     });
-    return sortUploads(mapUploadData(uploads));
+    uploadList = sortUploads(mapUploadData(uploads));
   }
-
-  const cachedUploadMetadataData = await redisClient.get(cacheKey);
-  if (cachedUploadMetadataData) {
-    try {
-      return JSON.parse(cachedUploadMetadataData);
+  else {
+    // metadata get all data flag is false -> get data from cache
+    const cachedUploadMetadataData = await redisClient.get(cacheKey);
+    if (cachedUploadMetadataData) {
+      try {
+        uploadList = JSON.parse(cachedUploadMetadataData) as UploadListItem[];
+      }
+      catch (error) {
+        logger.error(`Error parsing Redis data: ${error}`);
+        // fall through to fetch from database
+      }
     }
-    catch (error) {
-      logger.error(`Error parsing Redis data: ${error}`);
+    // if no cache yet -> fetch from DB and sort
+    if (uploadList.length === 0) {
+      const uploads = await prisma.upload.findMany({
+        where: { classId },
+        include,
+        orderBy,
+        take: 50
+      });
+      uploadList = sortUploads(mapUploadData(uploads));
+
+      // update cache and apply filter
+      try {
+        await updateCacheData(uploadList, cacheKey);
+      }
+      catch (err) {
+        logger.error(`Error updating Redis data: ${err}`);
+        // fall through to prevent unwanted crashes for users
+      }
     }
   }
-
-  const uploads = await prisma.upload.findMany({
-    where: { classId },
-    include,
-    orderBy,
-    take: 50
-  });
-  const uploadList = sortUploads(mapUploadData(uploads));
-
-  try {
-    await updateCacheData(uploadList, cacheKey);
-  }
-  catch (err) {
-    logger.error(`Error updating Redis data: ${err}`);
+  if (teamFilter) {
+    return uploadList.filter(upload => upload.teamId === -1 || teamFilter.has(upload.teamId));
   }
 
   return uploadList;
@@ -167,7 +164,7 @@ const uploadService = {
         classId: classIdNum,
         accountId,
         reservedBytes,
-        createdAt: Date.now()
+        createdAt: BigInt(Date.now())
       }
     });
 
@@ -576,6 +573,8 @@ const uploadService = {
       throw err;
     }
 
+    await isValidTeamId(uploadData.teamId, session);
+
     // Delete all physical files from disk
     const classDir = path.join(FINAL_UPLOADS_DIR, classIdNum.toString());
     for (const file of uploadData.Files) {
@@ -690,6 +689,8 @@ const uploadService = {
       };
       throw err;
     }
+
+    await isValidTeamId(existingRequest.teamId, session);
 
     await prisma.uploadRequest.delete({ where: { uploadRequestId } });
 

--- a/backend/src/utils/db.cleanup.ts
+++ b/backend/src/utils/db.cleanup.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { FINAL_UPLOADS_DIR } from "../config/upload";
 import { invalidateCache } from "./validate.functions";
 import socketIO from "../config/socket";
+import { encryptionManager } from "./encryption.manager";
 
 /**
  * Deletes class records that are older than 1 day and are TEST CLASSES
@@ -285,11 +286,15 @@ export async function migrateUploadMetadataDates(): Promise<void> {
   try {
     const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
 
+    const demoCodeCandidates = ["demo", "Demo"].map(code =>
+      encryptionManager.hash(code)
+    );
     const demoClass = await prisma.class.findFirst({
       where: {
         OR: [
-          { classCode: { equals: "demo", mode: "insensitive" } },
-          { className: { equals: "Demo", mode: "insensitive" } }
+          { className: { equals: "Demo", mode: "insensitive" } },
+          { classCodeHash: { in: demoCodeCandidates } },
+          { classCode: { equals: "demo", mode: "insensitive" } }
         ]
       }
     });
@@ -328,11 +333,15 @@ export async function migrateEventAndHomeworkDates(): Promise<void> {
   try {
     const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
 
+    const demoCodeCandidates = ["demo", "Demo"].map(code =>
+      encryptionManager.hash(code)
+    );
     const demoClass = await prisma.class.findFirst({
       where: {
         OR: [
-          { classCode: { equals: "demo", mode: "insensitive" } },
-          { className: { equals: "Demo", mode: "insensitive" } }
+          { className: { equals: "Demo", mode: "insensitive" } },
+          { classCodeHash: { in: demoCodeCandidates } },
+          { classCode: { equals: "demo", mode: "insensitive" } }
         ]
       }
     });

--- a/backend/src/utils/db.cleanup.ts
+++ b/backend/src/utils/db.cleanup.ts
@@ -65,6 +65,7 @@ export async function cleanupTestClasses(): Promise<void> {
     await Promise.all(
       classIdsToDelete.map(async classId => {
         await invalidateCache("UPLOADMETADATA", classId.toString());
+        await invalidateCache("UPLOADREQUESTS", classId.toString());
         await invalidateCache("HOMEWORK", classId.toString());
         await invalidateCache("EVENT", classId.toString());
         await invalidateCache("LESSON", classId.toString());
@@ -286,7 +287,7 @@ export async function migrateUploadMetadataDates(): Promise<void> {
   try {
     const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
 
-    const demoCodeCandidates = ["demo", "Demo"].map(code =>
+    const demoCodeCandidates = ["demo", "Demo", "DEMO", "DeMo"].map(code =>
       encryptionManager.hash(code)
     );
     const demoClass = await prisma.class.findFirst({

--- a/backend/src/utils/db.cleanup.ts
+++ b/backend/src/utils/db.cleanup.ts
@@ -287,7 +287,7 @@ export async function migrateUploadMetadataDates(): Promise<void> {
   try {
     const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
 
-    const demoCodeCandidates = ["demo", "Demo", "DEMO", "DeMo"].map(code =>
+    const demoCodeCandidates = ["demo", "Demo"].map(code =>
       encryptionManager.hash(code)
     );
     const demoClass = await prisma.class.findFirst({

--- a/backend/src/utils/encryption.manager.ts
+++ b/backend/src/utils/encryption.manager.ts
@@ -64,7 +64,7 @@ export class EncryptionManager {
     }
 
     const primaryKey = parseBase64Key(primaryKeyValue, "ENCRYPTION_KEY");
-    const lookupKey = parseBase64Key(lookupKeyValue, "ENCRYPTION_LOOKUP_KEY");
+    const lookupKey = parseBase64Key(lookupKeyValue, "ENCRYPTION_KEY_LOOKUP");
     const secondaryKeys = [parseBase64Key(secondaryKeyValue, "ENCRYPTION_KEY_SECONDARY")];
 
     return new EncryptionManager(primaryKey, secondaryKeys, lookupKey);

--- a/backend/src/utils/encryption.manager.ts
+++ b/backend/src/utils/encryption.manager.ts
@@ -1,13 +1,18 @@
 import {
   createCipheriv,
   createDecipheriv,
+  createHash,
   createHmac,
   hkdfSync,
   randomBytes
 } from "crypto";
+import logger from "../config/logger";
 
 const ENCRYPTION_PREFIX = "enc:v1:";
-const HKDF_SALT = Buffer.alloc(0);
+// Derive a fixed 32-byte salt from a descriptive string
+const HKDF_SALT = createHash("sha256")
+  .update("TaskMinder-Encryption-Key-Salt-v1", "utf8")
+  .digest();
 
 const deriveKey = (masterKey: Buffer, info: string): Buffer =>
   Buffer.from(hkdfSync("sha256", masterKey, HKDF_SALT, Buffer.from(info), 32));
@@ -28,14 +33,16 @@ const parseBase64Key = (keyValue: string, envName: string): Buffer => {
 export class EncryptionManager {
   private readonly primaryEncKey: Buffer;
   private readonly lookupKey: Buffer;
+  private readonly secondaryEncKeys: Buffer[];
   private readonly decryptKeys: Buffer[];
 
-  private constructor(primaryKey: Buffer, secondaryKeys: Buffer[]) {
+  private constructor(primaryKey: Buffer, secondaryKeys: Buffer[], lookupKey: Buffer) {
     this.primaryEncKey = deriveKey(primaryKey, "taskminder:enc");
-    this.lookupKey = deriveKey(primaryKey, "taskminder:lookup");
+    this.lookupKey = deriveKey(lookupKey, "taskminder:lookup");
+    this.secondaryEncKeys = secondaryKeys.map(key => deriveKey(key, "taskminder:enc"));
     this.decryptKeys = [
       this.primaryEncKey,
-      ...secondaryKeys.map(key => deriveKey(key, "taskminder:enc"))
+      ...this.secondaryEncKeys
     ];
   }
 
@@ -46,12 +53,21 @@ export class EncryptionManager {
     }
 
     const secondaryKeyValue = process.env.ENCRYPTION_KEY_SECONDARY;
-    const primaryKey = parseBase64Key(primaryKeyValue, "ENCRYPTION_KEY");
-    const secondaryKeys = secondaryKeyValue
-      ? [parseBase64Key(secondaryKeyValue, "ENCRYPTION_KEY_SECONDARY")]
-      : [];
+    if (!secondaryKeyValue) {
+      throw new Error("ENCRYPTION_KEY_SECONDARY is required.");
+    }
 
-    return new EncryptionManager(primaryKey, secondaryKeys);
+    const lookupKeyValue = process.env.ENCRYPTION_KEY_LOOKUP;
+
+    if (!lookupKeyValue) {
+      throw new Error("ENCRYPTION_KEY_LOOKUP is required.");
+    }
+
+    const primaryKey = parseBase64Key(primaryKeyValue, "ENCRYPTION_KEY");
+    const lookupKey = parseBase64Key(lookupKeyValue, "ENCRYPTION_LOOKUP_KEY");
+    const secondaryKeys = [parseBase64Key(secondaryKeyValue, "ENCRYPTION_KEY_SECONDARY")];
+
+    return new EncryptionManager(primaryKey, secondaryKeys, lookupKey);
   }
 
   isEncrypted(value: string): boolean {
@@ -78,7 +94,7 @@ export class EncryptionManager {
     return `${ENCRYPTION_PREFIX}${iv.toString("base64")}:${tag.toString("base64")}:${ciphertext.toString("base64")}`;
   }
 
-  decrypt(payload: string): string {
+  private decryptWithKeys(payload: string, keys: Buffer[]): string {
     if (!this.isEncrypted(payload)) {
       return payload;
     }
@@ -92,7 +108,7 @@ export class EncryptionManager {
     const tag = Buffer.from(parts[3], "base64");
     const ciphertext = Buffer.from(parts[4], "base64");
 
-    for (const key of this.decryptKeys) {
+    for (const key of keys) {
       try {
         const decipher = createDecipheriv("aes-256-gcm", key, iv);
         decipher.setAuthTag(tag);
@@ -103,11 +119,20 @@ export class EncryptionManager {
         return plaintext.toString("utf8");
       }
       catch {
+        // Intentionally do not log per-key failures to avoid timing/log side-channels
         continue;
       }
     }
-
+    logger.error("Unable to decrypt payload with available keys.");
     throw new Error("Unable to decrypt payload with available keys.");
+  }
+
+  decrypt(payload: string): string {
+    return this.decryptWithKeys(payload, this.decryptKeys);
+  }
+
+  decryptWithSecondary(payload: string): string {
+    return this.decryptWithKeys(payload, this.secondaryEncKeys);
   }
 }
 

--- a/backend/src/utils/encryption.manager.ts
+++ b/backend/src/utils/encryption.manager.ts
@@ -1,0 +1,114 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHmac,
+  hkdfSync,
+  randomBytes
+} from "crypto";
+
+const ENCRYPTION_PREFIX = "enc:v1:";
+const HKDF_SALT = Buffer.alloc(0);
+
+const deriveKey = (masterKey: Buffer, info: string): Buffer =>
+  Buffer.from(hkdfSync("sha256", masterKey, HKDF_SALT, Buffer.from(info), 32));
+
+const deriveLookupHash = (lookupKey: Buffer, plaintext: string): string =>
+  createHmac("sha256", lookupKey)
+    .update(plaintext, "utf8")
+    .digest("base64");
+
+const parseBase64Key = (keyValue: string, envName: string): Buffer => {
+  const key = Buffer.from(keyValue, "base64");
+  if (key.length !== 32) {
+    throw new Error(`${envName} must be 32 bytes (base64).`);
+  }
+  return key;
+};
+
+export class EncryptionManager {
+  private readonly primaryEncKey: Buffer;
+  private readonly lookupKey: Buffer;
+  private readonly decryptKeys: Buffer[];
+
+  private constructor(primaryKey: Buffer, secondaryKeys: Buffer[]) {
+    this.primaryEncKey = deriveKey(primaryKey, "taskminder:enc");
+    this.lookupKey = deriveKey(primaryKey, "taskminder:lookup");
+    this.decryptKeys = [
+      this.primaryEncKey,
+      ...secondaryKeys.map(key => deriveKey(key, "taskminder:enc"))
+    ];
+  }
+
+  static fromEnv(): EncryptionManager {
+    const primaryKeyValue = process.env.ENCRYPTION_KEY;
+    if (!primaryKeyValue) {
+      throw new Error("ENCRYPTION_KEY is required.");
+    }
+
+    const secondaryKeyValue = process.env.ENCRYPTION_KEY_SECONDARY;
+    const primaryKey = parseBase64Key(primaryKeyValue, "ENCRYPTION_KEY");
+    const secondaryKeys = secondaryKeyValue
+      ? [parseBase64Key(secondaryKeyValue, "ENCRYPTION_KEY_SECONDARY")]
+      : [];
+
+    return new EncryptionManager(primaryKey, secondaryKeys);
+  }
+
+  isEncrypted(value: string): boolean {
+    return value.startsWith(ENCRYPTION_PREFIX);
+  }
+
+  hash(plaintext: string): string {
+    return deriveLookupHash(this.lookupKey, plaintext);
+  }
+
+  encrypt(plaintext: string): string {
+    if (this.isEncrypted(plaintext)) {
+      return plaintext;
+    }
+
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", this.primaryEncKey, iv);
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext, "utf8"),
+      cipher.final()
+    ]);
+    const tag = cipher.getAuthTag();
+
+    return `${ENCRYPTION_PREFIX}${iv.toString("base64")}:${tag.toString("base64")}:${ciphertext.toString("base64")}`;
+  }
+
+  decrypt(payload: string): string {
+    if (!this.isEncrypted(payload)) {
+      return payload;
+    }
+
+    const parts = payload.split(":");
+    if (parts.length !== 5) {
+      throw new Error("Invalid encrypted payload format.");
+    }
+
+    const iv = Buffer.from(parts[2], "base64");
+    const tag = Buffer.from(parts[3], "base64");
+    const ciphertext = Buffer.from(parts[4], "base64");
+
+    for (const key of this.decryptKeys) {
+      try {
+        const decipher = createDecipheriv("aes-256-gcm", key, iv);
+        decipher.setAuthTag(tag);
+        const plaintext = Buffer.concat([
+          decipher.update(ciphertext),
+          decipher.final()
+        ]);
+        return plaintext.toString("utf8");
+      }
+      catch {
+        continue;
+      }
+    }
+
+    throw new Error("Unable to decrypt payload with available keys.");
+  }
+}
+
+export const encryptionManager = EncryptionManager.fromEnv();

--- a/backend/src/utils/encryption.migrate.ts
+++ b/backend/src/utils/encryption.migrate.ts
@@ -16,6 +16,14 @@ async function migrateClassCodes(): Promise<void> {
   const updated = await prisma.$transaction(async tx => {
     let updatedCount = 0;
     for (const classEntry of classes) {
+      if (
+        encryptionManager.isEncrypted(classEntry.classCode) &&
+        classEntry.classCodeHash === encryptionManager.hash(
+          encryptionManager.decrypt(classEntry.classCode)
+        )
+      ) {
+        continue;
+      }
       let plaintext = classEntry.classCode;
       if (encryptionManager.isEncrypted(classEntry.classCode)) {
         plaintext = encryptionManager.decrypt(classEntry.classCode);
@@ -23,12 +31,6 @@ async function migrateClassCodes(): Promise<void> {
 
       const encryptedCode = encryptionManager.encrypt(plaintext);
       const classCodeHash = encryptionManager.hash(plaintext);
-      if (
-        encryptionManager.isEncrypted(classEntry.classCode) &&
-        classEntry.classCodeHash === classCodeHash
-      ) {
-        continue;
-      }
       await tx.class.update({
         where: { classId: classEntry.classId },
         data: {

--- a/backend/src/utils/encryption.migrate.ts
+++ b/backend/src/utils/encryption.migrate.ts
@@ -1,0 +1,49 @@
+import prisma from "../config/prisma";
+import logger from "../config/logger";
+import { encryptionManager } from "./encryption.manager";
+
+async function migrateClassCodes(): Promise<void> {
+  const classes = await prisma.class.findMany({
+    select: {
+      classId: true,
+      classCode: true,
+      classCodeHash: true
+    }
+  });
+
+  let updated = 0;
+  for (const classEntry of classes) {
+    let plaintext = classEntry.classCode;
+    if (encryptionManager.isEncrypted(classEntry.classCode)) {
+      plaintext = encryptionManager.decrypt(classEntry.classCode);
+    }
+
+    const encryptedCode = encryptionManager.encrypt(plaintext);
+    const classCodeHash = encryptionManager.hash(plaintext);
+    if (
+      encryptionManager.isEncrypted(classEntry.classCode) &&
+      classEntry.classCodeHash === classCodeHash
+    ) {
+      continue;
+    }
+    await prisma.class.update({
+      where: { classId: classEntry.classId },
+      data: {
+        classCode: encryptedCode,
+        classCodeHash: classCodeHash
+      }
+    });
+    updated += 1;
+  }
+
+  logger.info(`Class code migration complete. Updated ${updated} records.`);
+}
+
+migrateClassCodes()
+  .catch(error => {
+    logger.error(`Failed to migrate class codes: ${error}`);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/utils/encryption.migrate.ts
+++ b/backend/src/utils/encryption.migrate.ts
@@ -1,3 +1,5 @@
+import * as dotenv from "dotenv";
+dotenv.config();
 import prisma from "../config/prisma";
 import logger from "../config/logger";
 import { encryptionManager } from "./encryption.manager";
@@ -11,30 +13,33 @@ async function migrateClassCodes(): Promise<void> {
     }
   });
 
-  let updated = 0;
-  for (const classEntry of classes) {
-    let plaintext = classEntry.classCode;
-    if (encryptionManager.isEncrypted(classEntry.classCode)) {
-      plaintext = encryptionManager.decrypt(classEntry.classCode);
-    }
-
-    const encryptedCode = encryptionManager.encrypt(plaintext);
-    const classCodeHash = encryptionManager.hash(plaintext);
-    if (
-      encryptionManager.isEncrypted(classEntry.classCode) &&
-      classEntry.classCodeHash === classCodeHash
-    ) {
-      continue;
-    }
-    await prisma.class.update({
-      where: { classId: classEntry.classId },
-      data: {
-        classCode: encryptedCode,
-        classCodeHash: classCodeHash
+  const updated = await prisma.$transaction(async tx => {
+    let updatedCount = 0;
+    for (const classEntry of classes) {
+      let plaintext = classEntry.classCode;
+      if (encryptionManager.isEncrypted(classEntry.classCode)) {
+        plaintext = encryptionManager.decrypt(classEntry.classCode);
       }
-    });
-    updated += 1;
-  }
+
+      const encryptedCode = encryptionManager.encrypt(plaintext);
+      const classCodeHash = encryptionManager.hash(plaintext);
+      if (
+        encryptionManager.isEncrypted(classEntry.classCode) &&
+        classEntry.classCodeHash === classCodeHash
+      ) {
+        continue;
+      }
+      await tx.class.update({
+        where: { classId: classEntry.classId },
+        data: {
+          classCode: encryptedCode,
+          classCodeHash: classCodeHash
+        }
+      });
+      updatedCount += 1;
+    }
+    return updatedCount;
+  });
 
   logger.info(`Class code migration complete. Updated ${updated} records.`);
 }

--- a/backend/src/utils/encryption.rotate.ts
+++ b/backend/src/utils/encryption.rotate.ts
@@ -1,3 +1,5 @@
+import * as dotenv from "dotenv";
+dotenv.config();
 import prisma from "../config/prisma";
 import logger from "../config/logger";
 import { encryptionManager } from "./encryption.manager";
@@ -15,28 +17,29 @@ async function rotateClassCodeKeys(): Promise<void> {
     }
   });
 
-  let updated = 0;
-  for (const classEntry of classes) {
-    const plaintext = encryptionManager.decrypt(classEntry.classCode);
-    const reEncrypted = encryptionManager.encrypt(plaintext);
-    const classCodeHash = encryptionManager.hash(plaintext);
-
-    if (
-      classEntry.classCode === reEncrypted &&
-      classEntry.classCodeHash === classCodeHash
-    ) {
-      continue;
-    }
-
-    await prisma.class.update({
-      where: { classId: classEntry.classId },
-      data: {
-        classCode: reEncrypted,
-        classCodeHash: classCodeHash
+  const updated = await prisma.$transaction(async tx => {
+    let updatedCount = 0;
+    for (const classEntry of classes) {
+      const plaintext = encryptionManager.decryptWithSecondary(classEntry.classCode);
+      const reEncrypted = encryptionManager.encrypt(plaintext);
+      const classCodeHash = encryptionManager.hash(plaintext);
+      if (
+        classEntry.classCode === reEncrypted &&
+        classEntry.classCodeHash === classCodeHash
+      ) {
+        continue;
       }
-    });
-    updated += 1;
-  }
+      await tx.class.update({
+        where: { classId: classEntry.classId },
+        data: {
+          classCode: reEncrypted,
+          classCodeHash: classCodeHash
+        }
+      });
+      updatedCount += 1;
+    }
+    return updatedCount;
+  });
 
   logger.info(`Key rotation complete. Re-encrypted ${updated} records.`);
 }

--- a/backend/src/utils/encryption.rotate.ts
+++ b/backend/src/utils/encryption.rotate.ts
@@ -21,20 +21,23 @@ async function rotateClassCodeKeys(): Promise<void> {
     let updatedCount = 0;
     for (const classEntry of classes) {
       let plaintext: string;
+      let decryptedWithSecondary = false;
       try {
         plaintext = encryptionManager.decrypt(classEntry.classCode);
       }
       catch {
         plaintext = encryptionManager.decryptWithSecondary(classEntry.classCode);
+        decryptedWithSecondary = true;
       }
-      const reEncrypted = encryptionManager.encrypt(plaintext);
+
       const classCodeHash = encryptionManager.hash(plaintext);
-      if (
-        classEntry.classCode === reEncrypted &&
-        classEntry.classCodeHash === classCodeHash
-      ) {
+
+      if (!decryptedWithSecondary && classEntry.classCodeHash === classCodeHash) {
         continue;
       }
+
+      const reEncrypted = encryptionManager.encrypt(plaintext);
+
       await tx.class.update({
         where: { classId: classEntry.classId },
         data: {

--- a/backend/src/utils/encryption.rotate.ts
+++ b/backend/src/utils/encryption.rotate.ts
@@ -1,0 +1,51 @@
+import prisma from "../config/prisma";
+import logger from "../config/logger";
+import { encryptionManager } from "./encryption.manager";
+
+async function rotateClassCodeKeys(): Promise<void> {
+  if (!process.env.ENCRYPTION_KEY_SECONDARY) {
+    throw new Error("ENCRYPTION_KEY_SECONDARY must be set to rotate keys.");
+  }
+
+  const classes = await prisma.class.findMany({
+    select: {
+      classId: true,
+      classCode: true,
+      classCodeHash: true
+    }
+  });
+
+  let updated = 0;
+  for (const classEntry of classes) {
+    const plaintext = encryptionManager.decrypt(classEntry.classCode);
+    const reEncrypted = encryptionManager.encrypt(plaintext);
+    const classCodeHash = encryptionManager.hash(plaintext);
+
+    if (
+      classEntry.classCode === reEncrypted &&
+      classEntry.classCodeHash === classCodeHash
+    ) {
+      continue;
+    }
+
+    await prisma.class.update({
+      where: { classId: classEntry.classId },
+      data: {
+        classCode: reEncrypted,
+        classCodeHash: classCodeHash
+      }
+    });
+    updated += 1;
+  }
+
+  logger.info(`Key rotation complete. Re-encrypted ${updated} records.`);
+}
+
+rotateClassCodeKeys()
+  .catch(error => {
+    logger.error(`Failed to rotate class code keys: ${error}`);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/utils/encryption.rotate.ts
+++ b/backend/src/utils/encryption.rotate.ts
@@ -20,7 +20,13 @@ async function rotateClassCodeKeys(): Promise<void> {
   const updated = await prisma.$transaction(async tx => {
     let updatedCount = 0;
     for (const classEntry of classes) {
-      const plaintext = encryptionManager.decryptWithSecondary(classEntry.classCode);
+      let plaintext: string;
+      try {
+        plaintext = encryptionManager.decrypt(classEntry.classCode);
+      }
+      catch {
+        plaintext = encryptionManager.decryptWithSecondary(classEntry.classCode);
+      }
       const reEncrypted = encryptionManager.encrypt(plaintext);
       const classCodeHash = encryptionManager.hash(plaintext);
       if (

--- a/backend/src/utils/validate.functions.ts
+++ b/backend/src/utils/validate.functions.ts
@@ -4,6 +4,16 @@ import prisma from "../config/prisma";
 import logger from "../config/logger";
 import { Session, SessionData } from "express-session";
 
+const BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+function generateRandomBase62String(length = 20): string {
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += BASE62.charAt(Math.floor(Math.random() * BASE62.length));
+  }
+  return result;
+}
+
 async function updateCacheData<T>(data: T[], key: string): Promise<void> {
   try {
     await redisClient.set(key, JSON.stringify(data, BigIntreplacer), 
@@ -70,10 +80,62 @@ async function isValidTeamId(teamId: number, session: Session & Partial<SessionD
       };
       throw err;
     }
+    if (teamExists.isPrivate) {
+      const accountId = session.account?.accountId;
+      if (!accountId) {
+        const err: RequestError = {
+          name: "Forbidden",
+          status: 403,
+          message: "Private team access requires an account",
+          expected: true
+        };
+        throw err;
+      }
+      const isMember = await prisma.joinedTeams.findUnique({
+        where: {
+          teamId_accountId: {
+            teamId: teamId,
+            accountId: accountId
+          }
+        }
+      });
+      if (!isMember) {
+        const err: RequestError = {
+          name: "Forbidden",
+          status: 403,
+          message: "You are not a member of this private team",
+          expected: true
+        };
+        throw err;
+      }
+    }
   }
   else {
     return;
   }
+}
+
+async function getAccessibleTeamIds(session: Session & Partial<SessionData>): Promise<number[]> {
+  const classId = parseInt(session.classId!, 10);
+  const teams = await prisma.team.findMany({
+    where: { classId },
+    select: { teamId: true, isPrivate: true }
+  });
+
+  const accountId = session.account?.accountId;
+  if (!accountId) {
+    return teams.filter(team => !team.isPrivate).map(team => team.teamId);
+  }
+
+  const joinedTeams = await prisma.joinedTeams.findMany({
+    where: { accountId },
+    select: { teamId: true }
+  });
+  const joinedTeamIds = new Set(joinedTeams.map(team => team.teamId));
+
+  return teams
+    .filter(team => !team.isPrivate || joinedTeamIds.has(team.teamId))
+    .map(team => team.teamId);
 }
 
 // @codescene(disable:"Code Duplication")
@@ -162,9 +224,11 @@ function lessonDateEventAtLeastOneNull(endDate: number | null, lesson: string | 
 }
 
 export {
+  generateRandomBase62String,
   isValidColor,
   isValidSubjectId,
   isValidTeamId,
+  getAccessibleTeamIds,
   isValidEventTypeId,
   isValidweekDay,
   lessonDateEventAtLeastOneNull,

--- a/backend/src/utils/validate.functions.ts
+++ b/backend/src/utils/validate.functions.ts
@@ -1,4 +1,5 @@
 import { RequestError } from "../@types/requestError";
+import { randomBytes } from "crypto";
 import { CACHE_KEY_PREFIXES, cacheExpiration, generateCacheKey, redisClient } from "../config/redis";
 import prisma from "../config/prisma";
 import logger from "../config/logger";
@@ -7,9 +8,10 @@ import { Session, SessionData } from "express-session";
 const BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 function generateRandomBase62String(length = 20): string {
+  const bytes = randomBytes(length);
   let result = "";
   for (let i = 0; i < length; i++) {
-    result += BASE62.charAt(Math.floor(Math.random() * BASE62.length));
+    result += BASE62.charAt(bytes[i] % BASE62.length);
   }
   return result;
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,8 @@ services:
       - session_secret
       - unsafe_deactivate_csp
       - database_url
+      - encryption_key
+      - encryption_key_secondary
     depends_on:
       postgres:
         condition: service_healthy
@@ -153,10 +155,12 @@ secrets:
     file: ./docker_secrets/unsafe_deactivate_csp.txt
   database_url:
     file: ./docker_secrets/database_url.txt
+  encryption_key:
+    file: ./docker_secrets/encryption_key.txt
+  encryption_key_secondary:
+    file: ./docker_secrets/encryption_key_secondary.txt
 
 volumes:
-  # remove the following line once migrated
-  postgres-data:
   postgres-data-18:
   prometheus-data:
   loki-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,6 +27,7 @@ services:
       - database_url
       - encryption_key
       - encryption_key_secondary
+      - encryption_key_lookup
     depends_on:
       postgres:
         condition: service_healthy
@@ -159,6 +160,8 @@ secrets:
     file: ./docker_secrets/encryption_key.txt
   encryption_key_secondary:
     file: ./docker_secrets/encryption_key_secondary.txt
+  encryption_key_lookup:
+    file: ./docker_secrets/encryption_key_lookup.txt
 
 volumes:
   postgres-data-18:

--- a/docs/src/data_processing.md
+++ b/docs/src/data_processing.md
@@ -68,7 +68,7 @@ This documentation describes all database tables defined in the current Prisma s
 | :--------------------- | :-------- | :--------------------------------------------- | :----------------------------------------------------------- |
 | classId                | Integer   | Unique class identifier                        | -                                                            |
 | className              | String    | The name of the class                          | May identify a specific group of students                    |
-| classCode              | String    | Unique encoded code for students to join the class     | Could lead to abusive joins if class code is breached        |
+| classCode              | String    | Unique encrypted code for students to join the class     | Could lead to abusive joins if class code is breached        |
 | classCodeHashed        | String    | Unique hashed code for students to join the class (fast lookup)    | Could lead to abusive joins if class code is breached        |
 | createdAt              | BigInt    | Timestamp of class creation                    | -                                                            |
 | isTestClass            | Boolean   | Flag to identify test/demo classes             | -                                                            |

--- a/docs/src/data_processing.md
+++ b/docs/src/data_processing.md
@@ -68,7 +68,8 @@ This documentation describes all database tables defined in the current Prisma s
 | :--------------------- | :-------- | :--------------------------------------------- | :----------------------------------------------------------- |
 | classId                | Integer   | Unique class identifier                        | -                                                            |
 | className              | String    | The name of the class                          | May identify a specific group of students                    |
-| classCode              | String    | Unique code for students to join the class     | Could lead to abusive joins if class code is breached        |
+| classCode              | String    | Unique encoded code for students to join the class     | Could lead to abusive joins if class code is breached        |
+| classCodeHashed        | String    | Unique hashed code for students to join the class (fast lookup)    | Could lead to abusive joins if class code is breached        |
 | createdAt              | BigInt    | Timestamp of class creation                    | -                                                            |
 | isTestClass            | Boolean   | Flag to identify test/demo classes             | -                                                            |
 | defaultPermissionLevel | Integer   | Default user permission level for new members  | -                                                            |
@@ -86,7 +87,7 @@ This documentation describes all database tables defined in the current Prisma s
 **Solutions**:
 - Implemented change class code function/button for class members.
 - Implemented strict access controls for rows containing third-party credentials.
-- Move to only store server-encrypted authId, no user or password
+- Implemented secure (aes-256-gcm) server-side encryption for class codes, 3rd-party (DSB Mobile) migration coming soon
 
 ---
 
@@ -302,8 +303,8 @@ To maintain and improve our service quality, we collect certain telemetry data, 
 
 ---
 
-- **Document Version:** 2.2
-- **Stable Version Alignment:** v2.2.5
-- **Last Updated:** January 16th, 2026
+- **Document Version:** 2.3
+- **Stable Version Alignment:** v2.3.0
+- **Last Updated:** February 1st, 2026
 - **Next Scheduled Review:** Quarterly – March 10th, 2026
 - **Technical Contact:** [info@taskminder.de](mailto:info@taskminder.de)

--- a/docs/src/data_processing.md
+++ b/docs/src/data_processing.md
@@ -69,7 +69,7 @@ This documentation describes all database tables defined in the current Prisma s
 | classId                | Integer   | Unique class identifier                        | -                                                            |
 | className              | String    | The name of the class                          | May identify a specific group of students                    |
 | classCode              | String    | Unique encrypted code for students to join the class     | Could lead to abusive joins if class code is breached        |
-| classCodeHashed        | String    | Unique hashed code for students to join the class (fast lookup)    | Could lead to abusive joins if class code is breached        |
+| classCodeHash          | String    | Unique hashed code for students to join the class (fast lookup)    | Could lead to abusive joins if class code is breached        |
 | createdAt              | BigInt    | Timestamp of class creation                    | -                                                            |
 | isTestClass            | Boolean   | Flag to identify test/demo classes             | -                                                            |
 | defaultPermissionLevel | Integer   | Default user permission level for new members  | -                                                            |

--- a/docs/src/data_processing.md
+++ b/docs/src/data_processing.md
@@ -201,18 +201,22 @@ This documentation describes all database tables defined in the current Prisma s
 
 ### 10. Team Table
 
-**Purpose**: Defines a specific group (team) within a class.
+**Purpose**: Defines a specific (invite-only) group (team) within a class.
 
-| Field   | Data Type | Intentionally Stored           | Potentially Unintentional                                     |
-| :------ | :-------- | :----------------------------- | :------------------------------------------------------------ |
-| teamId  | Integer   | Unique team identifier         | -                                                             |
-| name    | String    | Name of the team               | May be revealing (e.g., "Advanced Group", "Remedial Reading") |
-| classId | Integer   | Links team to a specific class | -                                                             |
-| createdAt | BigInt  | Record creation timestamp      | -                                                             |
+| Field         | Data Type | Intentionally Stored               | Potentially Unintentional                                     |
+| :-------------| :-------- | :--------------------------------- | :------------------------------------------------------------ |
+| teamId        | Integer   | Unique team identifier             | -                                                             |
+| name          | String    | Name of the team                   | May be revealing (e.g., "Advanced Group", "Remedial Reading") |
+| classId       | Integer   | Links team to a specific class     | -                                                             |
+| createdAt     | BigInt    | Record creation timestamp          | -                                                             |
+| isPrivate     | Boolean   | Flag for private team              | -                                                             |
+| inviteCode    | String    | Unique encrypted invite code       | Could lead to abusive joins if invite code is breached        |
+| inviteCodeHash| String    | Unique hashed invite code for fast lookup | Could lead to abusive joins if invite code is breached |
 
 **Privacy Concerns**:
 
 - The `name` of a team could imply academic level, behavioral status, or other sensitive classifications about its members.
+- Implemented secure (aes-256-gcm) server-side encryption for invite codes.
 
 ---
 
@@ -303,8 +307,8 @@ To maintain and improve our service quality, we collect certain telemetry data, 
 
 ---
 
-- **Document Version:** 2.3
+- **Document Version:** 2.4
 - **Stable Version Alignment:** v2.3.0
-- **Last Updated:** February 1st, 2026
+- **Last Updated:** February 4th, 2026
 - **Next Scheduled Review:** Quarterly – March 10th, 2026
 - **Technical Contact:** [info@taskminder.de](mailto:info@taskminder.de)

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -15,6 +15,10 @@ All changes are grouped by type and the latest version appears first.
 ### Changed
 * chore(api): rename and change type of API routes
 
+### Fixed
+* fix(request): upload requests are not deleted when team is deleted
+* fix(schema): remove unnecessary type infers from schemas
+
 ---
 
 ## \[v2.2.5] - 2026-02-??

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -4,6 +4,19 @@ All changes are grouped by type and the latest version appears first.
 
 ---
 
+## \[v2.3.0] - 2026-03-??
+
+### Breaking Change
+* feat(encryption): introduce server side encryption
+
+### Added
+* feat(team): add private teams (with invite link/code)
+
+### Changed
+* chore(api): rename and change type of API routes
+
+---
+
 ## \[v2.2.5] - 2026-02-??
 
 ### Breaking Change

--- a/docs/src/v2/deployment.md
+++ b/docs/src/v2/deployment.md
@@ -263,7 +263,7 @@ mkdir db-backups
 Before starting the application, create the following **text files inside the `docker_secrets/` folder**. These files are used as Docker secrets for configuration:
 
 | **Filename**                   | **Description**                                                                                                |
-| ---------------------------    | -------------------------------------------------------------------------------------------------------------- |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------- |
 | `db_name.txt`                  | Name of the PostgreSQL database.                                                                               |
 | `db_password.txt`              | Password for the PostgreSQL database user.                                                                     |
 | `db_host.txt`                  | Host for the database, usually postgres when running in docker.                                                |

--- a/docs/src/v2/deployment.md
+++ b/docs/src/v2/deployment.md
@@ -262,16 +262,19 @@ mkdir db-backups
 
 Before starting the application, create the following **text files inside the `docker_secrets/` folder**. These files are used as Docker secrets for configuration:
 
-| **Filename**                | **Description**                                                                                                |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `db_name.txt`               | Name of the PostgreSQL database.                                                                               |
-| `db_password.txt`           | Password for the PostgreSQL database user.                                                                     |
-| `db_host.txt`               | Host for the database, usually postgres when running in docker.                                                |
-| `db_user.txt`               | PostgreSQL database username.                                                                                  |
-| `redis_port.txt`            | Redis port (default is `6379`).                                                                                |
-| `session_secret.txt`        | Secure session secret (e.g., `ez829ebqhjui2638sbajk`).                                                         |
-| `unsafe_deactivate_csp.txt` | Deactivates all csp headers when set to `true`, in production, set to `false`.                                 |
-| `database_url.txt`          | Provides the database URL for Prisma ORM: `postgresql://db_user:db_password@taskminder-postgres:5432/db_name`. |
+| **Filename**                   | **Description**                                                                                                |
+| ---------------------------    | -------------------------------------------------------------------------------------------------------------- |
+| `db_name.txt`                  | Name of the PostgreSQL database.                                                                               |
+| `db_password.txt`              | Password for the PostgreSQL database user.                                                                     |
+| `db_host.txt`                  | Host for the database, usually postgres when running in docker.                                                |
+| `db_user.txt`                  | PostgreSQL database username.                                                                                  |
+| `redis_port.txt`               | Redis port (default is `6379`).                                                                                |
+| `session_secret.txt`           | Secure session secret (e.g., `ez829ebqhjui2638sbajk`).                                                         |
+| `unsafe_deactivate_csp.txt`    | Deactivates all csp headers when set to `true`, in production, set to `false`.                                 |
+| `database_url.txt`             | Provides the database URL for Prisma ORM: `postgresql://db_user:db_password@taskminder-postgres:5432/db_name`  |
+| `encryption_key.txt`           | Encryption key for server-side encryption in the database, generated with `openssl rand -base64 32`            |
+| `encryption_key_secondary.txt` | Rotation key for server-side encryption, generated with `openssl rand -base64 32`                              |
+| `encryption_key_lookup.txt`    | Lookup key for hashes for server-side encryption, generated with `openssl rand -base64 32`                     |
 
 ---
 

--- a/docs/src/v2/development.md
+++ b/docs/src/v2/development.md
@@ -19,7 +19,7 @@ This guide outlines the steps necessary to set up your development environment f
 
 ### Installing Redis and PostgreSQL
 
-**Recommended versions:** PostgreSQL 18.0+ and Redis v8+ (Redis Open Source).
+**Recommended versions:** PostgreSQL 18.1+ and Redis 8.4+ (Redis Open Source).
 
 <details open>
 <summary><strong>Linux (Ubuntu / Debian)</strong></summary>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,9 @@ export ENCRYPTION_KEY
 ENCRYPTION_KEY_SECONDARY="$(cat /run/secrets/encryption_key_secondary)"
 export ENCRYPTION_KEY_SECONDARY
 
+ENCRYPTION_KEY_LOOKUP="$(cat /run/secrets/encryption_key_lookup)"
+export ENCRYPTION_KEY_LOOKUP
+
 # ==============================================================================
 # Ensure permissions for data are returned to bun user
 # ==============================================================================

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,12 @@ export UNSAFE_DEACTIVATE_CSP
 DATABASE_URL="$(cat /run/secrets/database_url)"
 export DATABASE_URL
 
+ENCRYPTION_KEY="$(cat /run/secrets/encryption_key)"
+export ENCRYPTION_KEY
+
+ENCRYPTION_KEY_SECONDARY="$(cat /run/secrets/encryption_key_secondary)"
+export ENCRYPTION_KEY_SECONDARY
+
 # ==============================================================================
 # Ensure permissions for data are returned to bun user
 # ==============================================================================
@@ -47,12 +53,16 @@ echo "Running database migrations..."
 su-exec bun:bun bunx prisma migrate deploy
 
 # ==============================================================================
-# One time v2 migration cmds (as bun)
-# Do not uncomment if this is the first time setting up the server,
-# only when migrating from v1 to v2
+# One time migration cmd for server encryption (v2.3.0)
+# Ignore if first time setting up server or your current version is >= v2.3.0
 # ==============================================================================
-# su-exec bun:bun bunx prisma migrate resolve --applied 0_init
-# su-exec bun:bun bunx prisma migrate resolve --applied 20250804114621_migrate_to_multiple_classes
+# su-exec bun:bun bun run encrypt:migrate
+
+# ==============================================================================
+# Regular migration cmds for server encryption key rotation (>= v2.3.0)
+# Ignore if first time setting up server or your current version is < v2.3.0
+# ==============================================================================
+# su-exec bun:bun bun run encrypt:rotate
 
 # ======================================================================
 # Update ClamDB (as clamav)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskminder",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "",
   "main": "backend/dist/server.js",
   "scripts": {
@@ -28,7 +28,9 @@
     "dev:fe:copy": "chokidar 'frontend/src/**/*' -c 'bun copyFiles.js frontend/src frontend/dist'",
     "dev:start": "concurrently -n 'backend,frontend,server' \"bun run dev:be\" \"bun run dev:fe\" \"bun run dev:server\"",
     "dev": "bun run dev:start",
-    "dev-build": "bun run build && bun run dev:start"
+    "dev-build": "bun run build && bun run dev:start",
+    "encrypt:migrate": "bun backend/src/utils/encryption.migrate.ts",
+    "encrypt:rotate": "bun backend/src/utils/encryption.rotate.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
**CURRENT STATUS:** closed since main features have to be redesigned

Add server-side encryption and private teams backend infrastructure
This PR will be merged into develop after the v2.2.5 release.
closes #112, #94 with merge into main (v2.3.0)

**server-side-encryption:**
- add EncryptionManager using AES-256-GCM and HKDF-derived keys
- add lookup hashing via HMAC-SHA256 for deterministic searches
- support key rotation with secondary decrypt keys
- add migrate/rotate utilities and update db cleanup flow
- extend Prisma schema and add migration for class code hash
- wire encryption into server bootstrap and class service logic
- update env example, compose, entrypoint, docs, and package scripts

**private teams:**
- see #94 for implementation